### PR TITLE
test: add Linux GUI end-to-end coverage

### DIFF
--- a/.github/actions/setup-linux-desktop/action.yml
+++ b/.github/actions/setup-linux-desktop/action.yml
@@ -1,0 +1,130 @@
+name: Setup Linux desktop
+description: Start the deterministic X11 desktop used by Holo live E2E jobs.
+
+runs:
+  using: composite
+  steps:
+    - name: Install Linux desktop dependencies
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo apt-get update
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+          at-spi2-core \
+          dbus-x11 \
+          kcalc \
+          libatk-adaptor \
+          mousepad \
+          openbox \
+          picom \
+          python3-pyatspi \
+          python3-tk \
+          scrot \
+          thunar \
+          x11-utils \
+          xdotool \
+          xdg-utils \
+          xvfb
+
+        command -v google-chrome >/dev/null 2>&1 || command -v google-chrome-stable >/dev/null 2>&1 || {
+          echo "Google Chrome is not installed on the Ubuntu runner image" >&2
+          exit 1
+        }
+
+    - name: Start deterministic X11 session
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        log_dir="$RUNNER_TEMP/holo-linux-desktop-logs"
+        chrome_profile="$RUNNER_TEMP/holo-linux-chrome-profile"
+        mkdir -p "$log_dir" "$chrome_profile" "$HOME/Desktop" "$HOME/Downloads"
+
+        eval "$(dbus-launch --sh-syntax)"
+        export DBUS_SESSION_BUS_ADDRESS DBUS_SESSION_BUS_PID
+        export DISPLAY=:99
+        export GDK_BACKEND=x11
+        export QT_QPA_PLATFORM=xcb
+        export QT_ACCESSIBILITY=1
+        export QT_LINUX_ACCESSIBILITY_ALWAYS_ON=1
+        export NO_AT_BRIDGE=0
+        export HOLO_E2E_CHROME_PROFILE="$chrome_profile"
+
+        mousepad_desktop="$(find /usr/share/applications -maxdepth 1 -iname '*mousepad*.desktop' -printf '%f\n' | head -1)"
+        if [ -z "$mousepad_desktop" ]; then
+          echo "Mousepad desktop entry is missing" >&2
+          exit 1
+        fi
+        xdg-mime default "$mousepad_desktop" text/plain
+
+        {
+          echo "DISPLAY=$DISPLAY"
+          echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS"
+          echo "DBUS_SESSION_BUS_PID=$DBUS_SESSION_BUS_PID"
+          echo "GDK_BACKEND=$GDK_BACKEND"
+          echo "QT_QPA_PLATFORM=$QT_QPA_PLATFORM"
+          echo "QT_ACCESSIBILITY=$QT_ACCESSIBILITY"
+          echo "QT_LINUX_ACCESSIBILITY_ALWAYS_ON=$QT_LINUX_ACCESSIBILITY_ALWAYS_ON"
+          echo "NO_AT_BRIDGE=$NO_AT_BRIDGE"
+          echo "HOLO_E2E_CHROME_PROFILE=$HOLO_E2E_CHROME_PROFILE"
+          echo "HOLO_E2E_LINUX_LOG_DIR=$log_dir"
+        } >> "$GITHUB_ENV"
+
+        nohup Xvfb "$DISPLAY" -screen 0 1920x1080x24 -ac >"$log_dir/xvfb.log" 2>&1 &
+        echo $! > "$log_dir/xvfb.pid"
+
+        for _ in $(seq 1 50); do
+          if xdpyinfo -display "$DISPLAY" >/dev/null 2>&1; then
+            break
+          fi
+          sleep 0.2
+        done
+        xdpyinfo -display "$DISPLAY" >/dev/null
+
+        nohup openbox >"$log_dir/openbox.log" 2>&1 &
+        echo $! > "$log_dir/openbox.pid"
+        nohup picom --backend xrender >"$log_dir/picom.log" 2>&1 &
+        echo $! > "$log_dir/picom.pid"
+        nohup /usr/bin/python3 tests/e2e/_linux_launcher.py >"$log_dir/launcher.log" 2>&1 &
+        echo $! > "$log_dir/launcher.pid"
+
+        for _ in $(seq 1 50); do
+          if xdotool search --onlyvisible --name "Holo E2E Applications" >/dev/null 2>&1; then
+            break
+          fi
+          sleep 0.2
+        done
+        xdotool search --onlyvisible --name "Holo E2E Applications" >/dev/null
+        xdotool mousemove 25 25
+        xdotool mousemove 200 200
+        xdotool getmouselocation --shell > "$log_dir/pointer.txt"
+        grep -Fx "X=200" "$log_dir/pointer.txt"
+        grep -Fx "Y=200" "$log_dir/pointer.txt"
+        scrot -o "$log_dir/preflight.png"
+        test -s "$log_dir/preflight.png"
+
+        {
+          echo "## Linux desktop"
+          echo
+          echo "- Display: \`1920x1080x24\` on \`$DISPLAY\`"
+          echo "- Mousepad: \`$(mousepad --version 2>&1 | head -1)\`"
+          echo "- Thunar: \`$(thunar --version 2>&1 | head -1)\`"
+          echo "- KCalc: \`$(kcalc --version 2>&1 | head -1)\`"
+          if command -v google-chrome >/dev/null 2>&1; then
+            echo "- Chrome: \`$(google-chrome --version)\`"
+          else
+            echo "- Chrome: \`$(google-chrome-stable --version)\`"
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Print Linux desktop logs on setup failure
+      if: failure()
+      shell: bash
+      run: |
+        log_dir="$RUNNER_TEMP/holo-linux-desktop-logs"
+        for log in "$log_dir"/*.log; do
+          [ -f "$log" ] || continue
+          echo "::group::$(basename "$log")"
+          tail -n 200 "$log"
+          echo "::endgroup::"
+        done

--- a/.github/actions/setup-linux-desktop/action.yml
+++ b/.github/actions/setup-linux-desktop/action.yml
@@ -52,12 +52,22 @@ runs:
         export NO_AT_BRIDGE=0
         export HOLO_E2E_CHROME_PROFILE="$chrome_profile"
 
-        mousepad_desktop="$(find /usr/share/applications -maxdepth 1 -iname '*mousepad*.desktop' -printf '%f\n' | head -1)"
-        if [ -z "$mousepad_desktop" ]; then
-          echo "Mousepad desktop entry is missing" >&2
+        mapfile -t mousepad_desktop_candidates < <(
+          grep -lE '^Exec=(/usr/bin/)?mousepad([[:space:]]+%[FUfu])?[[:space:]]*$' \
+            /usr/share/applications/*mousepad*.desktop
+        )
+        if [ "${#mousepad_desktop_candidates[@]}" -ne 1 ]; then
+          echo "Expected exactly one Mousepad editor desktop entry, found ${#mousepad_desktop_candidates[@]}" >&2
+          grep -H '^Exec=' /usr/share/applications/*mousepad*.desktop >&2 || true
           exit 1
         fi
+        mousepad_desktop="$(basename "${mousepad_desktop_candidates[0]}")"
         xdg-mime default "$mousepad_desktop" text/plain
+        configured_mousepad_desktop="$(xdg-mime query default text/plain)"
+        if [ "$configured_mousepad_desktop" != "$mousepad_desktop" ]; then
+          echo "text/plain handler mismatch: expected $mousepad_desktop, got $configured_mousepad_desktop" >&2
+          exit 1
+        fi
 
         {
           echo "DISPLAY=$DISPLAY"
@@ -111,6 +121,30 @@ runs:
         xdotool getmouselocation --shell > "$log_dir/pointer.txt"
         grep -Fx "X=200" "$log_dir/pointer.txt"
         grep -Fx "Y=200" "$log_dir/pointer.txt"
+
+        mousepad_preflight="$RUNNER_TEMP/holo-linux-mousepad-preflight.txt"
+        printf 'mousepad preflight\n' > "$mousepad_preflight"
+        nohup xdg-open "$mousepad_preflight" >"$log_dir/mousepad-preflight.log" 2>&1 &
+        for _ in $(seq 1 100); do
+          if xdotool search --onlyvisible --name "$(basename "$mousepad_preflight")" >/dev/null 2>&1; then
+            break
+          fi
+          sleep 0.2
+        done
+        xdotool search --onlyvisible --name "$(basename "$mousepad_preflight")" >/dev/null
+        pkill -x mousepad || true
+        for _ in $(seq 1 50); do
+          if ! xdotool search --onlyvisible --name "$(basename "$mousepad_preflight")" >/dev/null 2>&1; then
+            break
+          fi
+          sleep 0.2
+        done
+        if xdotool search --onlyvisible --name "$(basename "$mousepad_preflight")" >/dev/null 2>&1; then
+          echo "Mousepad preflight window did not close" >&2
+          exit 1
+        fi
+        rm -f "$mousepad_preflight"
+
         scrot -o "$log_dir/preflight.png"
         test -s "$log_dir/preflight.png"
         gnome-screenshot -f "$log_dir/runtime-screenshot-preflight.png"
@@ -121,6 +155,7 @@ runs:
           echo
           echo "- Display: \`1920x1080x24\` on \`$DISPLAY\`"
           echo "- Mousepad: \`$(mousepad --version 2>&1 | head -1)\`"
+          echo "- text/plain handler: \`$mousepad_desktop\`"
           echo "- Thunar: \`$(thunar --version 2>&1 | head -1)\`"
           echo "- KCalc: \`$(kcalc --version 2>&1 | head -1)\`"
           if command -v google-chrome >/dev/null 2>&1; then

--- a/.github/actions/setup-linux-desktop/action.yml
+++ b/.github/actions/setup-linux-desktop/action.yml
@@ -85,6 +85,15 @@ runs:
 
         nohup openbox >"$log_dir/openbox.log" 2>&1 &
         echo $! > "$log_dir/openbox.pid"
+
+        for _ in $(seq 1 100); do
+          if xprop -root _NET_SUPPORTING_WM_CHECK 2>/dev/null | grep -q 'window id #'; then
+            break
+          fi
+          sleep 0.2
+        done
+        xprop -root _NET_SUPPORTING_WM_CHECK | grep -q 'window id #'
+
         nohup picom --backend xrender >"$log_dir/picom.log" 2>&1 &
         echo $! > "$log_dir/picom.pid"
         nohup /usr/bin/python3 tests/e2e/_linux_launcher.py >"$log_dir/launcher.log" 2>&1 &

--- a/.github/actions/setup-linux-desktop/action.yml
+++ b/.github/actions/setup-linux-desktop/action.yml
@@ -12,6 +12,7 @@ runs:
         sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
           at-spi2-core \
           dbus-x11 \
+          gnome-screenshot \
           kcalc \
           libatk-adaptor \
           mousepad \
@@ -89,7 +90,7 @@ runs:
         nohup /usr/bin/python3 tests/e2e/_linux_launcher.py >"$log_dir/launcher.log" 2>&1 &
         echo $! > "$log_dir/launcher.pid"
 
-        for _ in $(seq 1 50); do
+        for _ in $(seq 1 150); do
           if xdotool search --onlyvisible --name "Holo E2E Applications" >/dev/null 2>&1; then
             break
           fi
@@ -103,6 +104,8 @@ runs:
         grep -Fx "Y=200" "$log_dir/pointer.txt"
         scrot -o "$log_dir/preflight.png"
         test -s "$log_dir/preflight.png"
+        gnome-screenshot -f "$log_dir/runtime-screenshot-preflight.png"
+        test -s "$log_dir/runtime-screenshot-preflight.png"
 
         {
           echo "## Linux desktop"

--- a/.github/actions/setup-linux-desktop/action.yml
+++ b/.github/actions/setup-linux-desktop/action.yml
@@ -39,6 +39,7 @@ runs:
         log_dir="$RUNNER_TEMP/holo-linux-desktop-logs"
         chrome_profile="$RUNNER_TEMP/holo-linux-chrome-profile"
         mkdir -p "$log_dir" "$chrome_profile" "$HOME/Desktop" "$HOME/Downloads"
+        touch "$HOME/.Xauthority"
 
         eval "$(dbus-launch --sh-syntax)"
         export DBUS_SESSION_BUS_ADDRESS DBUS_SESSION_BUS_PID

--- a/.github/workflows/holo-full-e2e.yml
+++ b/.github/workflows/holo-full-e2e.yml
@@ -30,7 +30,7 @@ jobs:
       # Keep live model traffic bounded. Launching all platform shards together can
       # starve turns before the first observation is emitted, leaving no actionable
       # task/evaluator evidence and consuming the entire per-task timeout.
-      max-parallel: 4
+      max-parallel: 2
       matrix:
         include:
           - os: macos-14

--- a/.github/workflows/holo-full-e2e.yml
+++ b/.github/workflows/holo-full-e2e.yml
@@ -27,6 +27,10 @@ jobs:
       )
     strategy:
       fail-fast: false
+      # Keep live model traffic bounded. Launching all platform shards together can
+      # starve turns before the first observation is emitted, leaving no actionable
+      # task/evaluator evidence and consuming the entire per-task timeout.
+      max-parallel: 4
       matrix:
         include:
           - os: macos-14

--- a/.github/workflows/holo-full-e2e.yml
+++ b/.github/workflows/holo-full-e2e.yml
@@ -3,6 +3,15 @@ name: Holo Full E2E
 on:
   workflow_dispatch:
     inputs:
+      platform:
+        description: "Platform to run (all keeps the release posture)"
+        type: choice
+        options:
+          - all
+          - linux
+          - darwin
+          - win32
+        default: all
       fast:
         description: "Run with fast mode (--fast: one screenshot, no thinking, smaller uploads)"
         type: boolean
@@ -15,8 +24,43 @@ permissions:
   id-token: write
 
 jobs:
+  plan:
+    name: plan full-e2e matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.result }}
+    steps:
+      - name: Select platform shards
+        id: matrix
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const platforms = [
+              { os: 'macos-14', platform: 'darwin', platform_name: 'macOS' },
+              { os: 'windows-latest', platform: 'win32', platform_name: 'Windows' },
+              { os: 'ubuntu-22.04', platform: 'linux', platform_name: 'Linux' },
+            ];
+            const selected = context.payload.inputs?.platform || 'all';
+            const allowed = new Set(['all', ...platforms.map(({ platform }) => platform)]);
+            if (!allowed.has(selected)) {
+              core.setFailed(`Unsupported platform selection: ${selected}`);
+              return JSON.stringify({ include: [] });
+            }
+            const include = platforms
+              .filter(({ platform }) => selected === 'all' || platform === selected)
+              .flatMap((entry) => Array.from({ length: 4 }, (_, shard_index) => ({
+                ...entry,
+                shard_index,
+                shard_total: 4,
+                shard_display: `${shard_index + 1}/4`,
+              })));
+            core.info(`Selected ${include.length} shard(s) for ${selected}`);
+            return JSON.stringify({ include });
+
   full-e2e:
     name: full-e2e (${{ matrix.platform_name }} shard ${{ matrix.shard_display }})
+    needs: plan
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (
@@ -31,80 +75,7 @@ jobs:
       # starve turns before the first observation is emitted, leaving no actionable
       # task/evaluator evidence and consuming the entire per-task timeout.
       max-parallel: 2
-      matrix:
-        include:
-          - os: macos-14
-            platform: darwin
-            platform_name: macOS
-            shard_index: 0
-            shard_total: 4
-            shard_display: 1/4
-          - os: macos-14
-            platform: darwin
-            platform_name: macOS
-            shard_index: 1
-            shard_total: 4
-            shard_display: 2/4
-          - os: macos-14
-            platform: darwin
-            platform_name: macOS
-            shard_index: 2
-            shard_total: 4
-            shard_display: 3/4
-          - os: macos-14
-            platform: darwin
-            platform_name: macOS
-            shard_index: 3
-            shard_total: 4
-            shard_display: 4/4
-          - os: windows-latest
-            platform: win32
-            platform_name: Windows
-            shard_index: 0
-            shard_total: 4
-            shard_display: 1/4
-          - os: windows-latest
-            platform: win32
-            platform_name: Windows
-            shard_index: 1
-            shard_total: 4
-            shard_display: 2/4
-          - os: windows-latest
-            platform: win32
-            platform_name: Windows
-            shard_index: 2
-            shard_total: 4
-            shard_display: 3/4
-          - os: windows-latest
-            platform: win32
-            platform_name: Windows
-            shard_index: 3
-            shard_total: 4
-            shard_display: 4/4
-          - os: ubuntu-22.04
-            platform: linux
-            platform_name: Linux
-            shard_index: 0
-            shard_total: 4
-            shard_display: 1/4
-          - os: ubuntu-22.04
-            platform: linux
-            platform_name: Linux
-            shard_index: 1
-            shard_total: 4
-            shard_display: 2/4
-          - os: ubuntu-22.04
-            platform: linux
-            platform_name: Linux
-            shard_index: 2
-            shard_total: 4
-            shard_display: 3/4
-          - os: ubuntu-22.04
-            platform: linux
-            platform_name: Linux
-            shard_index: 3
-            shard_total: 4
-            shard_display: 4/4
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     env:

--- a/.github/workflows/holo-full-e2e.yml
+++ b/.github/workflows/holo-full-e2e.yml
@@ -77,6 +77,30 @@ jobs:
             shard_index: 3
             shard_total: 4
             shard_display: 4/4
+          - os: ubuntu-22.04
+            platform: linux
+            platform_name: Linux
+            shard_index: 0
+            shard_total: 4
+            shard_display: 1/4
+          - os: ubuntu-22.04
+            platform: linux
+            platform_name: Linux
+            shard_index: 1
+            shard_total: 4
+            shard_display: 2/4
+          - os: ubuntu-22.04
+            platform: linux
+            platform_name: Linux
+            shard_index: 2
+            shard_total: 4
+            shard_display: 3/4
+          - os: ubuntu-22.04
+            platform: linux
+            platform_name: Linux
+            shard_index: 3
+            shard_total: 4
+            shard_display: 4/4
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     env:
@@ -87,6 +111,10 @@ jobs:
       PYTHONUTF8: "1"
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup Linux desktop
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/setup-linux-desktop
 
       - name: Configure shard artifact paths
         shell: bash
@@ -354,6 +382,7 @@ jobs:
           path: |
             ${{ env.HOLO_E2E_ARTIFACT_ROOT }}
             ${{ env.HOLO_E2E_REPORT_DIR }}
+            ${{ runner.temp }}/holo-linux-desktop-logs/
           if-no-files-found: warn
           retention-days: 14
 

--- a/.github/workflows/holo-live-smoke.yml
+++ b/.github/workflows/holo-live-smoke.yml
@@ -257,7 +257,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: holo-live-smoke-${{ runner.os }}
-          path: |
-            ~/.holo/e2e-review/
-            ${{ runner.temp }}/holo-linux-desktop-logs/
+          path: ~/.holo/e2e-review/
           if-no-files-found: error
+
+      - name: Upload Linux desktop logs
+        if: always() && runner.os == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: holo-live-smoke-Linux-desktop-logs
+          path: ${{ runner.temp }}/holo-linux-desktop-logs/
+          if-no-files-found: warn

--- a/.github/workflows/holo-live-smoke.yml
+++ b/.github/workflows/holo-live-smoke.yml
@@ -21,8 +21,9 @@ jobs:
         include:
           - os: macos-14
           - os: windows-latest
+          - os: ubuntu-22.04
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     env:
       AWS_REGION: us-west-2
       HAI_API_KEY_SECRET_ID: ${{ vars.HAI_API_KEY_SECRET_ID }}
@@ -31,6 +32,10 @@ jobs:
       PYTHONUTF8: "1"
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup Linux desktop
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/setup-linux-desktop
 
       - name: Log GitHub OIDC claims
         uses: actions/github-script@v7
@@ -252,5 +257,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: holo-live-smoke-${{ runner.os }}
-          path: ~/.holo/e2e-review/
+          path: |
+            ~/.holo/e2e-review/
+            ${{ runner.temp }}/holo-linux-desktop-logs/
           if-no-files-found: error

--- a/tests/e2e/COVERAGE.md
+++ b/tests/e2e/COVERAGE.md
@@ -5,16 +5,23 @@ Each task should prefer a deterministic system assertion over answer judging.
 
 ## Current Coverage
 
-The PR-gated full e2e workflow keeps only task fixtures that passed 3/3 on both
-macOS and Windows during initial hosted-runner QA:
+The PR-gated full e2e workflow runs the same task fixtures on macOS, Windows,
+and the Ubuntu 22.04 X11 posture:
 
 - Text input: foreground visible editor witness and type sentinel.
-- File manager basics: create folder, copy file, and protected-file no-op.
+- File manager basics: create folder, copy file, open by double-click, and protected-file no-op.
 - Calculator/UI readback: calculator CI smoke.
 - Browser: local download.
 
-Task fixtures that did not meet the 3/3 bar on both hosted platforms were
-removed from this suite rather than kept as CI coverage.
+Any fixture that does not meet the 3/3 bar on all three hosted platforms should
+be removed from this suite rather than kept as CI coverage.
+
+The Linux mappings are release-candidate coverage until three independent
+hosted workflow runs qualify each task at that same 3/3 bar.
+
+Linux maps the same product contracts to Mousepad, Thunar, KCalc, and Google
+Chrome. Filesystem evaluators stay shared; KCalc uses independent AT-SPI
+readback and the double-click task uses visible-window title inspection.
 
 ## OSWorld-Light Mapping
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -10,6 +10,11 @@ Run requirements that bite:
 - **Launch from a user terminal.** macOS TCC attributes Accessibility / Screen
   Recording to the responsible process; runs spawned from agent/automation
   contexts inherit a context without grants and synthetic input fails silently.
+- **Linux uses the CI X11 posture.** Linux live runs require Xvfb (or another X11
+  display), Openbox, Picom, a session D-Bus with AT-SPI, and the Mousepad,
+  Thunar, KCalc, and Google Chrome app pack. The canonical setup is
+  `.github/actions/setup-linux-desktop/action.yml`; it also starts the visible
+  `Holo E2E Applications` launcher used by cold-start tasks.
 
 ## GitHub Actions full-suite QA
 
@@ -19,13 +24,13 @@ Maintainers can opt in a trusted same-repo PR by applying the `run-holo-full-e2e
 label. Applying the label starts one run; later pushes do not rerun the suite
 while the label remains attached. To request another run, remove and reapply the
 label or use `workflow_dispatch`. The workflow runs the shared 3/3 stable task
-catalog on fixed macOS and Windows shard jobs in parallel, executes one task
+catalog on fixed macOS, Windows, and Ubuntu 22.04 shard jobs in parallel, executes one task
 per pytest invocation inside each shard, appends each task result to the GitHub
 step summary, uploads `~/.holo`-style e2e artifacts, and writes a final pass-rate
 report.
 
-The workflow uses four shards per OS. With the current 7-task stable catalog,
-that means eight desktop jobs total and roughly one to two tasks per shard. This
+The workflow uses four shards per OS. With the current 8-task stable catalog,
+that means twelve desktop jobs total and two tasks per shard. This
 keeps macOS concurrency below the common five-job hosted-runner cap while still
 reducing wall-clock time compared with one sequential runner per OS.
 
@@ -33,6 +38,24 @@ The workflow does not run with secrets on forked PRs. Use `workflow_dispatch` fo
 manual branch or release-candidate validation.
 
 For release QA, run the workflow three times and compare the per-task pass
-buckets. Keep tasks in HoloDesktop CI only when they pass 3/3 on both hosted
+buckets. Keep tasks in HoloDesktop CI only when they pass 3/3 on all three hosted
 platforms; remove hard or inconsistent task fixtures from this suite until they
 are consistently reliable.
+
+## Linux local reproduction
+
+On Ubuntu 22.04, reproduce the hosted posture by following the package and
+session setup in `.github/actions/setup-linux-desktop/action.yml`, then run one
+task with the normal live flags:
+
+```bash
+uv sync --all-groups
+uv run pytest tests/e2e/test_live_foreground.py \
+  --run-holo-live-foreground \
+  --holo-live-task-ids calculator_ci_smoke \
+  --holo-live-timeout 180 \
+  --capture=tee-sys -q
+```
+
+This Linux lane proves the shipped x86_64 managed runtime on Ubuntu 22.04 under
+X11. It does not claim Wayland, Linux ARM64, GPU, or broad distro compatibility.

--- a/tests/e2e/_artifacts.py
+++ b/tests/e2e/_artifacts.py
@@ -112,8 +112,13 @@ class E2EArtifacts:
     def copy_runtime_log(self, runtime_log_path: Path | None) -> Path | None:
         if runtime_log_path is None or not runtime_log_path.exists():
             return None
-        shutil.copy2(runtime_log_path, self.runtime_log_path)
-        return self.runtime_log_path
+        destination = self.runtime_log_path
+        attempt = 2
+        while destination.exists():
+            destination = self.root / f"runtime-attempt-{attempt}.log"
+            attempt += 1
+        shutil.copy2(runtime_log_path, destination)
+        return destination
 
     def preserve_final_artifacts(self, prepared_task: PreparedTask) -> None:
         self.final_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/e2e/_artifacts.py
+++ b/tests/e2e/_artifacts.py
@@ -26,6 +26,8 @@ class E2EResult(BaseModel):
     duration_s: float | None
     event_log_path: Path | None
     copied_event_log_path: Path | None
+    runtime_log_path: Path | None = None
+    copied_runtime_log_path: Path | None = None
     assertion_passed: bool
     failure_category: str | None
     artifact_dir: Path
@@ -46,6 +48,7 @@ class E2EArtifacts:
     before_screenshot_path: Path
     after_screenshot_path: Path
     events_path: Path
+    runtime_log_path: Path
     final_dir: Path
 
     @classmethod
@@ -63,6 +66,7 @@ class E2EArtifacts:
             before_screenshot_path=root / "screen-before.png",
             after_screenshot_path=root / "screen-after.png",
             events_path=root / "events.jsonl",
+            runtime_log_path=root / "runtime.log",
             final_dir=root / "final",
         )
         artifacts.write_platform_metadata()
@@ -104,6 +108,12 @@ class E2EArtifacts:
             return None
         shutil.copy2(event_log_path, self.events_path)
         return self.events_path
+
+    def copy_runtime_log(self, runtime_log_path: Path | None) -> Path | None:
+        if runtime_log_path is None or not runtime_log_path.exists():
+            return None
+        shutil.copy2(runtime_log_path, self.runtime_log_path)
+        return self.runtime_log_path
 
     def preserve_final_artifacts(self, prepared_task: PreparedTask) -> None:
         self.final_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/e2e/_environment.py
+++ b/tests/e2e/_environment.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 
 from ._domain import EnvironmentRunner
+from .environments.linux import LinuxEnvironmentRunner
 from .environments.macos import MacOSEnvironmentRunner
 from .environments.windows import WindowsEnvironmentRunner
 
@@ -19,9 +20,11 @@ def runner_for_platform(platform: str) -> EnvironmentRunner:
             return MacOSEnvironmentRunner()
         case "win32":
             return WindowsEnvironmentRunner()
+        case "linux":
+            return LinuxEnvironmentRunner()
         case _:
             raise UnsupportedEnvironmentError(
-                f"foreground live e2e tests support macOS and Windows only; got {platform!r}"
+                f"foreground live e2e tests support macOS, Windows, and Linux only; got {platform!r}"
             )
 
 

--- a/tests/e2e/_harness.py
+++ b/tests/e2e/_harness.py
@@ -67,6 +67,7 @@ def run_and_evaluate(
         copied_event_log = artifacts.copy_event_log(event_log_path)
         if copied_event_log is None:
             copied_event_log = artifacts.copy_event_log(find_latest_event_log(artifacts.runs_dir))
+        copied_runtime_log = artifacts.copy_runtime_log(run_result.runtime_log_path if run_result else None)
         timing = extract_step_timings(copied_event_log)
         artifacts.write_result(
             E2EResult(
@@ -79,6 +80,8 @@ def run_and_evaluate(
                 duration_s=run_result.duration_s if run_result else None,
                 event_log_path=run_result.event_log_path if run_result else None,
                 copied_event_log_path=copied_event_log,
+                runtime_log_path=run_result.runtime_log_path if run_result else None,
+                copied_runtime_log_path=copied_runtime_log,
                 assertion_passed=passed,
                 failure_category=failure_category.value if failure_category else None,
                 artifact_dir=artifacts.root,

--- a/tests/e2e/_linux.py
+++ b/tests/e2e/_linux.py
@@ -265,9 +265,8 @@ def visit(node, depth=0):
         return
     text = ""
     try:
-        if node.getState().contains(pyatspi.STATE_SHOWING):
-            text_iface = node.queryText()
-            text = text_iface.getText(0, text_iface.characterCount)
+        text_iface = node.queryText()
+        text = text_iface.getText(0, text_iface.characterCount)
     except Exception:
         pass
     if name or text:

--- a/tests/e2e/_linux.py
+++ b/tests/e2e/_linux.py
@@ -116,10 +116,24 @@ def cleanup_desktop_artifacts() -> None:
                 path.unlink(missing_ok=True)
 
 
-def cleanup_process(name: str) -> None:
+def cleanup_process(name: str, *, timeout: float = 5.0) -> None:
     with suppress(FileNotFoundError, subprocess.TimeoutExpired):
-        subprocess.run(["pkill", "-x", name], capture_output=True, check=False, timeout=5.0)
-    time.sleep(0.1)
+        subprocess.run(["pkill", "-TERM", "-x", name], capture_output=True, check=False, timeout=5.0)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        running = _run(["pgrep", "-x", name], timeout=2.0)
+        if running.returncode != 0:
+            return
+        time.sleep(0.1)
+    with suppress(FileNotFoundError, subprocess.TimeoutExpired):
+        subprocess.run(["pkill", "-KILL", "-x", name], capture_output=True, check=False, timeout=5.0)
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        running = _run(["pgrep", "-x", name], timeout=2.0)
+        if running.returncode != 0:
+            return
+        time.sleep(0.1)
+    raise RuntimeError(f"failed to stop Linux process {name!r}; remaining pids: {running.stdout.strip()}")
 
 
 def cleanup_editor_and_desktop() -> None:
@@ -146,13 +160,22 @@ def cleanup_chrome() -> None:
     profile = Path(os.environ.get("HOLO_E2E_CHROME_PROFILE", "/tmp/holo-e2e-chrome-profile"))
     with suppress(FileNotFoundError, subprocess.TimeoutExpired):
         subprocess.run(
-            ["pkill", "-f", f"--user-data-dir={profile}"],
+            ["pkill", "-TERM", "-f", f"--user-data-dir={profile}"],
             capture_output=True,
             check=False,
             timeout=5.0,
         )
+    cleanup_process("chrome")
+    cleanup_process("google-chrome")
     shutil.rmtree(profile, ignore_errors=True)
     profile.mkdir(parents=True, exist_ok=True)
+
+
+def cleanup_test_apps() -> None:
+    cleanup_process("mousepad")
+    cleanup_process("thunar")
+    cleanup_process("kcalc")
+    cleanup_chrome()
 
 
 def opened_file_window(filename: str, titles: list[str] | None = None) -> str | None:

--- a/tests/e2e/_linux.py
+++ b/tests/e2e/_linux.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import time
+import uuid
+from contextlib import suppress
+from pathlib import Path
+
+import pytest
+
+from ._domain import EvaluationResult, FailureCategory, FlatMetadata
+from .evaluators.calculator import calculator_result_part
+
+DESKTOP = Path.home() / "Desktop"
+DOWNLOADS = Path.home() / "Downloads"
+ARTIFACT_PREFIX = "0holoe2e"
+LAUNCHER_TITLE = "Holo E2E Applications"
+
+
+def unique_token(label: str) -> str:
+    safe_label = "".join(char for char in label.lower() if char.isalnum())
+    return f"{ARTIFACT_PREFIX}{safe_label}{uuid.uuid4().hex[:8]}"
+
+
+def require_desktop() -> None:
+    missing = [command for command in ("xdpyinfo", "xdotool", "scrot") if shutil.which(command) is None]
+    if missing:
+        _unavailable(f"missing Linux desktop commands: {', '.join(missing)}")
+    if not os.environ.get("DISPLAY"):
+        _unavailable("DISPLAY is not set")
+    for directory in (DESKTOP, DOWNLOADS):
+        if not directory.is_dir():
+            _unavailable(f"required directory does not exist: {directory}")
+    display = _run(["xdpyinfo"], timeout=5.0)
+    if display.returncode != 0:
+        _unavailable(f"X11 display is unavailable: {display.stderr.strip()}")
+    screenshot = _run(["scrot", "-o", "/tmp/holo-e2e-preflight.png"], timeout=10.0)
+    screenshot_path = Path("/tmp/holo-e2e-preflight.png")
+    if screenshot.returncode != 0 or not screenshot_path.is_file() or screenshot_path.stat().st_size == 0:
+        _unavailable(f"X11 screenshot failed: {screenshot.stderr.strip()}")
+    if find_window(LAUNCHER_TITLE) is None:
+        _unavailable(f"visible application launcher is missing: {LAUNCHER_TITLE}")
+
+
+def require_app(command: str) -> None:
+    alternatives = (command, "google-chrome-stable") if command == "google-chrome" else (command,)
+    if not any(shutil.which(candidate) for candidate in alternatives):
+        _unavailable(f"required Linux app is unavailable: {command}")
+
+
+def open_in_mousepad(path: Path) -> None:
+    cleanup_process("mousepad")
+    subprocess.Popen(
+        ["mousepad", str(path)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    wait_for_window(path.name)
+
+
+def open_desktop_in_thunar() -> None:
+    cleanup_process("thunar")
+    subprocess.Popen(
+        ["thunar", str(DESKTOP)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    wait_for_window("Desktop")
+
+
+def wait_for_window(pattern: str, *, timeout: float = 10.0) -> str:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        match = find_window(pattern)
+        if match is not None:
+            _activate_window(match[0])
+            return match[1]
+        time.sleep(0.2)
+    raise RuntimeError(f"timed out waiting for visible Linux window matching {pattern!r}")
+
+
+def find_window(pattern: str) -> tuple[str, str] | None:
+    for window_id, title in visible_windows():
+        if pattern.casefold() in title.casefold():
+            return window_id, title
+    return None
+
+
+def visible_windows() -> list[tuple[str, str]]:
+    search = _run(["xdotool", "search", "--onlyvisible", "--name", ".*"], timeout=5.0)
+    if search.returncode != 0:
+        return []
+    windows: list[tuple[str, str]] = []
+    for window_id in search.stdout.splitlines():
+        window_id = window_id.strip()
+        if not window_id:
+            continue
+        title = _run(["xdotool", "getwindowname", window_id], timeout=2.0)
+        if title.returncode == 0 and title.stdout.strip():
+            windows.append((window_id, title.stdout.strip()))
+    return windows
+
+
+def cleanup_desktop_artifacts() -> None:
+    for pattern in (f"{ARTIFACT_PREFIX}*", "holo_e2e_*"):
+        for path in DESKTOP.glob(pattern):
+            if path.is_dir():
+                shutil.rmtree(path, ignore_errors=True)
+            else:
+                path.unlink(missing_ok=True)
+
+
+def cleanup_process(name: str) -> None:
+    with suppress(FileNotFoundError, subprocess.TimeoutExpired):
+        subprocess.run(["pkill", "-x", name], capture_output=True, check=False, timeout=5.0)
+    time.sleep(0.1)
+
+
+def cleanup_editor_and_desktop() -> None:
+    cleanup_process("mousepad")
+    cleanup_desktop_artifacts()
+
+
+def cleanup_file_manager_and_desktop() -> None:
+    cleanup_process("thunar")
+    cleanup_desktop_artifacts()
+
+
+def cleanup_opened_file_task() -> None:
+    cleanup_process("mousepad")
+    cleanup_process("thunar")
+    cleanup_desktop_artifacts()
+
+
+def cleanup_calculator() -> None:
+    cleanup_process("kcalc")
+
+
+def cleanup_chrome() -> None:
+    profile = Path(os.environ.get("HOLO_E2E_CHROME_PROFILE", "/tmp/holo-e2e-chrome-profile"))
+    with suppress(FileNotFoundError, subprocess.TimeoutExpired):
+        subprocess.run(
+            ["pkill", "-f", f"--user-data-dir={profile}"],
+            capture_output=True,
+            check=False,
+            timeout=5.0,
+        )
+    shutil.rmtree(profile, ignore_errors=True)
+    profile.mkdir(parents=True, exist_ok=True)
+
+
+def opened_file_window(filename: str, titles: list[str] | None = None) -> str | None:
+    path = Path(filename)
+    candidates = (path.name, path.stem)
+    for title in titles if titles is not None else [title for _, title in visible_windows()]:
+        folded = title.casefold()
+        if "mousepad" in folded and any(candidate.casefold() in folded for candidate in candidates if candidate):
+            return title
+    return None
+
+
+class LinuxOpenedFileEvaluator:
+    """Proves a seeded file is open in a visible Mousepad window."""
+
+    name = "linux_opened_file"
+
+    def __init__(self, path: Path, expected_content: str) -> None:
+        self.path = path
+        self.expected_content = expected_content
+
+    def evaluate(self) -> EvaluationResult:
+        metadata: FlatMetadata = {"path": str(self.path)}
+        if not self.path.exists():
+            return EvaluationResult(
+                passed=False,
+                message=f"file disappeared before open check: {self.path}",
+                failure_category=FailureCategory.AGENT,
+                metadata=metadata,
+            )
+        if self.path.read_text(encoding="utf-8", errors="replace") != self.expected_content:
+            return EvaluationResult(
+                passed=False,
+                message="seeded file content changed before open check",
+                failure_category=FailureCategory.AGENT,
+                metadata=metadata,
+            )
+        titles = [title for _, title in visible_windows()]
+        matching_title = opened_file_window(self.path.name, titles)
+        metadata["visible_window_titles"] = titles
+        if matching_title is None:
+            return EvaluationResult(
+                passed=False,
+                message="seeded file was not visible in a Mousepad window",
+                failure_category=FailureCategory.AGENT,
+                metadata=metadata,
+            )
+        return EvaluationResult(
+            passed=True,
+            message="file opened in Mousepad",
+            metadata={**metadata, "mousepad_window_title": matching_title},
+        )
+
+
+class LinuxCalculatorResultEvaluator:
+    """Checks KCalc's visible result through the independent AT-SPI tree."""
+
+    name = "linux_calculator_result"
+
+    def __init__(self, *, a: int, b: int, expected: int) -> None:
+        self.a = a
+        self.b = b
+        self.expected = expected
+
+    def evaluate(self) -> EvaluationResult:
+        entries = kcalc_accessible_entries()
+        display = kcalc_display_from_entries(entries)
+        metadata: FlatMetadata = {
+            "a": self.a,
+            "b": self.b,
+            "expected": self.expected,
+            "accessible_entries": [json.dumps(entry, sort_keys=True) for entry in entries],
+        }
+        if display is None:
+            return EvaluationResult(
+                passed=False,
+                message="KCalc display unreadable via AT-SPI",
+                failure_category=FailureCategory.EVALUATOR,
+                metadata=metadata,
+            )
+        result_part = kcalc_result_part(display)
+        if result_part != str(self.expected):
+            return EvaluationResult(
+                passed=False,
+                message=f"KCalc result mismatch: expected {self.expected!r}, got {result_part!r}",
+                failure_category=FailureCategory.AGENT,
+                metadata={**metadata, "display": display, "result_part": result_part},
+            )
+        return EvaluationResult(
+            passed=True,
+            message="KCalc result matched",
+            metadata={**metadata, "display": display, "result_part": result_part},
+        )
+
+
+def kcalc_accessible_entries() -> list[dict[str, str]]:
+    script = r"""
+import json
+import pyatspi
+
+rows = []
+
+def visit(node, depth=0):
+    if depth > 20:
+        return
+    try:
+        name = node.name or ""
+        role = node.getRoleName() or ""
+    except Exception:
+        return
+    text = ""
+    try:
+        if node.getState().contains(pyatspi.STATE_SHOWING):
+            text_iface = node.queryText()
+            text = text_iface.getText(0, text_iface.characterCount)
+    except Exception:
+        pass
+    if name or text:
+        rows.append({"name": name, "role": role, "text": text})
+    try:
+        for child in node:
+            visit(child, depth + 1)
+    except Exception:
+        pass
+
+desktop = pyatspi.Registry.getDesktop(0)
+for app in desktop:
+    try:
+        if "kcalc" in (app.name or "").lower():
+            visit(app)
+    except Exception:
+        pass
+print(json.dumps(rows))
+"""
+    proc = _run(["/usr/bin/python3", "-c", script], timeout=10.0)
+    if proc.returncode != 0:
+        return []
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(payload, list):
+        return []
+    return [
+        {key: str(value) for key, value in item.items() if key in {"name", "role", "text"}}
+        for item in payload
+        if isinstance(item, dict)
+    ]
+
+
+def kcalc_display_from_entries(entries: list[dict[str, str]]) -> str | None:
+    display_candidates: list[str] = []
+    text_candidates: list[str] = []
+    numeric_candidates: list[str] = []
+    for entry in entries:
+        role = entry.get("role", "").casefold()
+        values = [entry.get("text", "").strip(), entry.get("name", "").strip()]
+        for value in values:
+            if not value:
+                continue
+            if "display" in entry.get("name", "").casefold() or "display" in role:
+                display_candidates.append(value)
+            if any(kind in role for kind in ("text", "entry", "edit")) and "button" not in role:
+                text_candidates.append(value)
+            if "button" not in role and re.fullmatch(r"[\s\u200e\u200f\d.,+\-*/=]+", value):
+                numeric_candidates.append(value)
+    for candidates in (display_candidates, text_candidates, numeric_candidates):
+        for candidate in reversed(candidates):
+            if re.search(r"\d", candidate):
+                return candidate
+    return None
+
+
+def kcalc_result_part(display: str) -> str:
+    result = calculator_result_part(display)
+    if "=" in result:
+        result = result.rsplit("=", 1)[-1]
+    return result.strip()
+
+
+def preserve_kcalc_display(artifact_dir: Path) -> None:
+    entries = kcalc_accessible_entries()
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    (artifact_dir / "kcalc-atspi.json").write_text(json.dumps(entries, indent=2), encoding="utf-8")
+    display = kcalc_display_from_entries(entries)
+    (artifact_dir / "kcalc-display.txt").write_text(f"{display or ''}\n", encoding="utf-8")
+
+
+def preserve_window_titles(artifact_dir: Path) -> None:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    titles = [title for _, title in visible_windows()]
+    (artifact_dir / "visible-window-titles.txt").write_text("\n".join(titles) + "\n", encoding="utf-8")
+
+
+def _activate_window(window_id: str) -> None:
+    _run(["xdotool", "windowactivate", "--sync", window_id], timeout=5.0)
+    _run(["xdotool", "windowfocus", "--sync", window_id], timeout=5.0)
+
+
+def _run(args: list[str], *, timeout: float) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(args, capture_output=True, text=True, check=False, timeout=timeout)
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        return subprocess.CompletedProcess(args, 127, "", f"{type(exc).__name__}: {exc}")
+
+
+def _unavailable(message: str) -> None:
+    if os.environ.get("GITHUB_ACTIONS", "").lower() == "true":
+        pytest.fail(message)
+    pytest.skip(message)

--- a/tests/e2e/_linux.py
+++ b/tests/e2e/_linux.py
@@ -127,13 +127,6 @@ def cleanup_process(name: str, *, timeout: float = 5.0) -> None:
         time.sleep(0.1)
     with suppress(FileNotFoundError, subprocess.TimeoutExpired):
         subprocess.run(["pkill", "-KILL", "-x", name], capture_output=True, check=False, timeout=5.0)
-    deadline = time.monotonic() + 2.0
-    while time.monotonic() < deadline:
-        running = _run(["pgrep", "-x", name], timeout=2.0)
-        if running.returncode != 0:
-            return
-        time.sleep(0.1)
-    raise RuntimeError(f"failed to stop Linux process {name!r}; remaining pids: {running.stdout.strip()}")
 
 
 def cleanup_editor_and_desktop() -> None:
@@ -165,8 +158,16 @@ def cleanup_chrome() -> None:
             check=False,
             timeout=5.0,
         )
-    cleanup_process("chrome")
-    cleanup_process("google-chrome")
+    cleanup_process("chrome", timeout=1.0)
+    cleanup_process("google-chrome", timeout=1.0)
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        chrome_titles = [title for _, title in visible_windows() if "chrome" in title.casefold()]
+        if not chrome_titles:
+            break
+        time.sleep(0.1)
+    else:
+        raise RuntimeError(f"failed to close Chrome windows: {chrome_titles}")
     shutil.rmtree(profile, ignore_errors=True)
     profile.mkdir(parents=True, exist_ok=True)
 

--- a/tests/e2e/_linux.py
+++ b/tests/e2e/_linux.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import json
 import os
-import re
 import shutil
 import subprocess
 import time
@@ -11,9 +9,6 @@ from contextlib import suppress
 from pathlib import Path
 
 import pytest
-
-from ._domain import EvaluationResult, FailureCategory, FlatMetadata
-from .evaluators.calculator import calculator_result_part
 
 DESKTOP = Path.home() / "Desktop"
 DOWNLOADS = Path.home() / "Downloads"
@@ -35,10 +30,10 @@ def require_desktop() -> None:
     for directory in (DESKTOP, DOWNLOADS):
         if not directory.is_dir():
             _unavailable(f"required directory does not exist: {directory}")
-    display = _run(["xdpyinfo"], timeout=5.0)
+    display = run_command(["xdpyinfo"], timeout=5.0)
     if display.returncode != 0:
         _unavailable(f"X11 display is unavailable: {display.stderr.strip()}")
-    screenshot = _run(["scrot", "-o", "/tmp/holo-e2e-preflight.png"], timeout=10.0)
+    screenshot = run_command(["scrot", "-o", "/tmp/holo-e2e-preflight.png"], timeout=10.0)
     screenshot_path = Path("/tmp/holo-e2e-preflight.png")
     if screenshot.returncode != 0 or not screenshot_path.is_file() or screenshot_path.stat().st_size == 0:
         _unavailable(f"X11 screenshot failed: {screenshot.stderr.strip()}")
@@ -93,7 +88,7 @@ def find_window(pattern: str) -> tuple[str, str] | None:
 
 
 def visible_windows() -> list[tuple[str, str]]:
-    search = _run(["xdotool", "search", "--onlyvisible", "--name", ".*"], timeout=5.0)
+    search = run_command(["xdotool", "search", "--onlyvisible", "--name", ".*"], timeout=5.0)
     if search.returncode != 0:
         return []
     windows: list[tuple[str, str]] = []
@@ -101,7 +96,7 @@ def visible_windows() -> list[tuple[str, str]]:
         window_id = window_id.strip()
         if not window_id:
             continue
-        title = _run(["xdotool", "getwindowname", window_id], timeout=2.0)
+        title = run_command(["xdotool", "getwindowname", window_id], timeout=2.0)
         if title.returncode == 0 and title.stdout.strip():
             windows.append((window_id, title.stdout.strip()))
     return windows
@@ -121,7 +116,7 @@ def cleanup_process(name: str, *, timeout: float = 5.0) -> None:
         subprocess.run(["pkill", "-TERM", "-x", name], capture_output=True, check=False, timeout=5.0)
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        running = _run(["pgrep", "-x", name], timeout=2.0)
+        running = run_command(["pgrep", "-x", name], timeout=2.0)
         if running.returncode != 0:
             return
         time.sleep(0.1)
@@ -179,203 +174,12 @@ def cleanup_test_apps() -> None:
     cleanup_chrome()
 
 
-def opened_file_window(filename: str, titles: list[str] | None = None) -> str | None:
-    path = Path(filename)
-    candidates = (path.name, path.stem)
-    for title in titles if titles is not None else [title for _, title in visible_windows()]:
-        folded = title.casefold()
-        if "mousepad" in folded and any(candidate.casefold() in folded for candidate in candidates if candidate):
-            return title
-    return None
-
-
-class LinuxOpenedFileEvaluator:
-    """Proves a seeded file is open in a visible Mousepad window."""
-
-    name = "linux_opened_file"
-
-    def __init__(self, path: Path, expected_content: str) -> None:
-        self.path = path
-        self.expected_content = expected_content
-
-    def evaluate(self) -> EvaluationResult:
-        metadata: FlatMetadata = {"path": str(self.path)}
-        if not self.path.exists():
-            return EvaluationResult(
-                passed=False,
-                message=f"file disappeared before open check: {self.path}",
-                failure_category=FailureCategory.AGENT,
-                metadata=metadata,
-            )
-        if self.path.read_text(encoding="utf-8", errors="replace") != self.expected_content:
-            return EvaluationResult(
-                passed=False,
-                message="seeded file content changed before open check",
-                failure_category=FailureCategory.AGENT,
-                metadata=metadata,
-            )
-        titles = [title for _, title in visible_windows()]
-        matching_title = opened_file_window(self.path.name, titles)
-        metadata["visible_window_titles"] = titles
-        if matching_title is None:
-            return EvaluationResult(
-                passed=False,
-                message="seeded file was not visible in a Mousepad window",
-                failure_category=FailureCategory.AGENT,
-                metadata=metadata,
-            )
-        return EvaluationResult(
-            passed=True,
-            message="file opened in Mousepad",
-            metadata={**metadata, "mousepad_window_title": matching_title},
-        )
-
-
-class LinuxCalculatorResultEvaluator:
-    """Checks KCalc's visible result through the independent AT-SPI tree."""
-
-    name = "linux_calculator_result"
-
-    def __init__(self, *, a: int, b: int, expected: int) -> None:
-        self.a = a
-        self.b = b
-        self.expected = expected
-
-    def evaluate(self) -> EvaluationResult:
-        entries = kcalc_accessible_entries()
-        display = kcalc_display_from_entries(entries)
-        metadata: FlatMetadata = {
-            "a": self.a,
-            "b": self.b,
-            "expected": self.expected,
-            "accessible_entries": [json.dumps(entry, sort_keys=True) for entry in entries],
-        }
-        if display is None:
-            return EvaluationResult(
-                passed=False,
-                message="KCalc display unreadable via AT-SPI",
-                failure_category=FailureCategory.EVALUATOR,
-                metadata=metadata,
-            )
-        result_part = kcalc_result_part(display)
-        if result_part != str(self.expected):
-            return EvaluationResult(
-                passed=False,
-                message=f"KCalc result mismatch: expected {self.expected!r}, got {result_part!r}",
-                failure_category=FailureCategory.AGENT,
-                metadata={**metadata, "display": display, "result_part": result_part},
-            )
-        return EvaluationResult(
-            passed=True,
-            message="KCalc result matched",
-            metadata={**metadata, "display": display, "result_part": result_part},
-        )
-
-
-def kcalc_accessible_entries() -> list[dict[str, str]]:
-    script = r"""
-import json
-import pyatspi
-
-rows = []
-
-def visit(node, depth=0):
-    if depth > 20:
-        return
-    try:
-        name = node.name or ""
-        role = node.getRoleName() or ""
-    except Exception:
-        return
-    text = ""
-    try:
-        text_iface = node.queryText()
-        text = text_iface.getText(0, text_iface.characterCount)
-    except Exception:
-        pass
-    if name or text:
-        rows.append({"name": name, "role": role, "text": text})
-    try:
-        for child in node:
-            visit(child, depth + 1)
-    except Exception:
-        pass
-
-desktop = pyatspi.Registry.getDesktop(0)
-for app in desktop:
-    try:
-        if "kcalc" in (app.name or "").lower():
-            visit(app)
-    except Exception:
-        pass
-print(json.dumps(rows))
-"""
-    proc = _run(["/usr/bin/python3", "-c", script], timeout=10.0)
-    if proc.returncode != 0:
-        return []
-    try:
-        payload = json.loads(proc.stdout)
-    except json.JSONDecodeError:
-        return []
-    if not isinstance(payload, list):
-        return []
-    return [
-        {key: str(value) for key, value in item.items() if key in {"name", "role", "text"}}
-        for item in payload
-        if isinstance(item, dict)
-    ]
-
-
-def kcalc_display_from_entries(entries: list[dict[str, str]]) -> str | None:
-    display_candidates: list[str] = []
-    text_candidates: list[str] = []
-    numeric_candidates: list[str] = []
-    for entry in entries:
-        role = entry.get("role", "").casefold()
-        values = [entry.get("text", "").strip(), entry.get("name", "").strip()]
-        for value in values:
-            if not value:
-                continue
-            if "display" in entry.get("name", "").casefold() or "display" in role:
-                display_candidates.append(value)
-            if any(kind in role for kind in ("text", "entry", "edit")) and "button" not in role:
-                text_candidates.append(value)
-            if "button" not in role and re.fullmatch(r"[\s\u200e\u200f\d.,+\-*/=]+", value):
-                numeric_candidates.append(value)
-    for candidates in (display_candidates, text_candidates, numeric_candidates):
-        for candidate in reversed(candidates):
-            if re.search(r"\d", candidate):
-                return candidate
-    return None
-
-
-def kcalc_result_part(display: str) -> str:
-    result = calculator_result_part(display)
-    if "=" in result:
-        result = result.rsplit("=", 1)[-1]
-    return result.strip()
-
-
-def preserve_kcalc_display(artifact_dir: Path) -> None:
-    entries = kcalc_accessible_entries()
-    artifact_dir.mkdir(parents=True, exist_ok=True)
-    (artifact_dir / "kcalc-atspi.json").write_text(json.dumps(entries, indent=2), encoding="utf-8")
-    display = kcalc_display_from_entries(entries)
-    (artifact_dir / "kcalc-display.txt").write_text(f"{display or ''}\n", encoding="utf-8")
-
-
-def preserve_window_titles(artifact_dir: Path) -> None:
-    artifact_dir.mkdir(parents=True, exist_ok=True)
-    titles = [title for _, title in visible_windows()]
-    (artifact_dir / "visible-window-titles.txt").write_text("\n".join(titles) + "\n", encoding="utf-8")
-
-
 def _activate_window(window_id: str) -> None:
-    _run(["xdotool", "windowactivate", "--sync", window_id], timeout=5.0)
-    _run(["xdotool", "windowfocus", "--sync", window_id], timeout=5.0)
+    run_command(["xdotool", "windowactivate", "--sync", window_id], timeout=5.0)
+    run_command(["xdotool", "windowfocus", "--sync", window_id], timeout=5.0)
 
 
-def _run(args: list[str], *, timeout: float) -> subprocess.CompletedProcess[str]:
+def run_command(args: list[str], *, timeout: float) -> subprocess.CompletedProcess[str]:
     try:
         return subprocess.run(args, capture_output=True, text=True, check=False, timeout=timeout)
     except (FileNotFoundError, subprocess.TimeoutExpired) as exc:

--- a/tests/e2e/_linux_launcher.py
+++ b/tests/e2e/_linux_launcher.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tkinter as tk
+from pathlib import Path
+
+
+def main() -> None:
+    root = tk.Tk()
+    root.title("Holo E2E Applications")
+    root.geometry("330x310+20+20")
+    root.attributes("-topmost", False)
+
+    heading = tk.Label(root, text="Applications", font=("Sans", 20, "bold"), pady=12)
+    heading.pack(fill=tk.X)
+
+    apps = (
+        ("Mousepad", ["mousepad"]),
+        ("Thunar", ["thunar", str(Path.home() / "Desktop")]),
+        ("KCalc", ["kcalc"]),
+        ("Google Chrome", _chrome_command()),
+    )
+    for label, command in apps:
+        button = tk.Button(root, text=label, font=("Sans", 15), height=2, command=lambda cmd=command: _launch(cmd))
+        button.pack(fill=tk.X, padx=24, pady=4)
+
+    root.mainloop()
+
+
+def _chrome_command() -> list[str]:
+    binary = shutil.which("google-chrome") or shutil.which("google-chrome-stable")
+    if binary is None:
+        return ["false"]
+    profile = Path(os.environ.get("HOLO_E2E_CHROME_PROFILE", "/tmp/holo-e2e-chrome-profile"))
+    profile.mkdir(parents=True, exist_ok=True)
+    return [
+        binary,
+        f"--user-data-dir={profile}",
+        "--no-first-run",
+        "--no-default-browser-check",
+        "--disable-search-engine-choice-screen",
+        "--disable-features=Translate",
+        "about:blank",
+    ]
+
+
+def _launch(command: list[str]) -> None:
+    subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/_report.py
+++ b/tests/e2e/_report.py
@@ -319,6 +319,8 @@ def _environment_id_for_platform(platform: str | None) -> str:
         return "macos-foreground"
     if platform == "Windows":
         return "windows-foreground"
+    if platform == "Linux":
+        return "linux-foreground"
     return "unknown"
 
 
@@ -368,7 +370,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--platform")
     parser.add_argument("--report-dir", type=Path)
     parser.add_argument("--append-step-summary", action="store_true")
-    parser.add_argument("--list-task-ids-for-platform", choices=["darwin", "win32"])
+    parser.add_argument("--list-task-ids-for-platform", choices=["darwin", "win32", "linux"])
     parser.add_argument("--shard-index", type=int)
     parser.add_argument("--shard-total", type=int)
     parser.add_argument("--append-task-summary", action="store_true")

--- a/tests/e2e/_runner.py
+++ b/tests/e2e/_runner.py
@@ -18,6 +18,7 @@ from .conftest import HoloLiveConfig
 
 _EVENT_LOG_RE = re.compile(r"events streamed to\s+(.+)")
 TIMEOUT_SHUTDOWN_GRACE_S = 10.0
+RUNTIME_DIAGNOSTIC_LOG_LEVEL = "DEBUG"
 
 
 def free_port() -> int:
@@ -120,6 +121,7 @@ def run_holo_foreground(
         command.extend(["--model", config.model])
     if config.base_url:
         command.extend(["--base-url", config.base_url])
+    runtime_env = {**os.environ, "HAI_AGENT_RUNTIME_LOG_LEVEL": RUNTIME_DIAGNOSTIC_LOG_LEVEL}
     start = time.monotonic()
     if not stream_output:
         try:
@@ -127,6 +129,7 @@ def run_holo_foreground(
                 command=command,
                 runs_dir=runs_dir,
                 agent_runtime_log_path=agent_runtime_log_path,
+                env=runtime_env,
                 timeout_s=config.timeout_s,
                 start=start,
             )
@@ -142,6 +145,7 @@ def run_holo_foreground(
         stderr=subprocess.PIPE,
         text=True,
         bufsize=1,
+        env=runtime_env,
     )
     stdout_thread = _tee_stream(proc.stdout, sys.stdout, stdout_chunks)
     stderr_thread = _tee_stream(proc.stderr, sys.stderr, stderr_chunks)
@@ -174,6 +178,7 @@ def _run_holo_captured(
     command: list[str],
     runs_dir: Path,
     agent_runtime_log_path: Path,
+    env: dict[str, str],
     timeout_s: float,
     start: float,
 ) -> HoloRunResult:
@@ -183,6 +188,7 @@ def _run_holo_captured(
             cwd=Path(__file__).resolve().parents[2],
             capture_output=True,
             text=True,
+            env=env,
             timeout=timeout_s,
             check=False,
         )

--- a/tests/e2e/_runner.py
+++ b/tests/e2e/_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+import signal
 import socket
 import subprocess
 import sys
@@ -11,9 +12,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import IO, TextIO
 
+from holo_desktop.agent_client.launcher import runtime_log_path
+
 from .conftest import HoloLiveConfig
 
 _EVENT_LOG_RE = re.compile(r"events streamed to\s+(.+)")
+TIMEOUT_SHUTDOWN_GRACE_S = 10.0
 
 
 def free_port() -> int:
@@ -69,6 +73,7 @@ class HoloRunResult:
     stderr: str
     duration_s: float
     event_log_path: Path | None
+    runtime_log_path: Path | None = None
 
 
 def run_holo_foreground(
@@ -87,6 +92,7 @@ def run_holo_foreground(
         subprocess_timeout_s=config.timeout_s,
     )
     port = free_port()
+    agent_runtime_log_path = runtime_log_path(port)
     command = [
         "uv",
         "run",
@@ -120,6 +126,7 @@ def run_holo_foreground(
             return _run_holo_captured(
                 command=command,
                 runs_dir=runs_dir,
+                agent_runtime_log_path=agent_runtime_log_path,
                 timeout_s=config.timeout_s,
                 start=start,
             )
@@ -141,10 +148,9 @@ def run_holo_foreground(
     try:
         exit_code = proc.wait(timeout=config.timeout_s)
     except subprocess.TimeoutExpired:
-        proc.kill()
+        cleanup = _graceful_timeout_cleanup(proc)
         exit_code = 124
-        stderr_chunks.append(f"\nTimed out after {config.timeout_s}s")
-        proc.wait()
+        stderr_chunks.append(f"\nTimed out after {config.timeout_s}s; {cleanup}")
     finally:
         kill_port_listener(port)
     stdout_thread.join(timeout=1.0)
@@ -159,6 +165,7 @@ def run_holo_foreground(
         stderr=stderr,
         duration_s=duration,
         event_log_path=find_event_log_path(stderr) or find_latest_event_log(runs_dir),
+        runtime_log_path=agent_runtime_log_path if agent_runtime_log_path.exists() else None,
     )
 
 
@@ -166,6 +173,7 @@ def _run_holo_captured(
     *,
     command: list[str],
     runs_dir: Path,
+    agent_runtime_log_path: Path,
     timeout_s: float,
     start: float,
 ) -> HoloRunResult:
@@ -190,6 +198,7 @@ def _run_holo_captured(
             stderr=stderr,
             duration_s=duration,
             event_log_path=find_event_log_path(stderr) or find_latest_event_log(runs_dir),
+            runtime_log_path=agent_runtime_log_path if agent_runtime_log_path.exists() else None,
         )
     duration = time.monotonic() - start
     event_log_path = find_event_log_path(proc.stderr) or find_latest_event_log(runs_dir)
@@ -200,7 +209,29 @@ def _run_holo_captured(
         stderr=proc.stderr,
         duration_s=duration,
         event_log_path=event_log_path,
+        runtime_log_path=agent_runtime_log_path if agent_runtime_log_path.exists() else None,
     )
+
+
+def _graceful_timeout_cleanup(proc: subprocess.Popen[str]) -> str:
+    """Ask ``holo run`` to cancel its session before resorting to a force-kill."""
+
+    try:
+        if os.name == "nt":
+            proc.terminate()
+            signal_name = "terminate"
+        else:
+            proc.send_signal(signal.SIGINT)
+            signal_name = "SIGINT"
+        proc.wait(timeout=TIMEOUT_SHUTDOWN_GRACE_S)
+        return f"{signal_name} cleanup completed"
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+        return f"{signal_name} cleanup exceeded {TIMEOUT_SHUTDOWN_GRACE_S:g}s; force-killed"
+    except ProcessLookupError:
+        proc.wait()
+        return "process exited during timeout cleanup"
 
 
 def _tee_stream(

--- a/tests/e2e/_runner.py
+++ b/tests/e2e/_runner.py
@@ -18,7 +18,6 @@ from .conftest import HoloLiveConfig
 
 _EVENT_LOG_RE = re.compile(r"events streamed to\s+(.+)")
 TIMEOUT_SHUTDOWN_GRACE_S = 10.0
-RUNTIME_DIAGNOSTIC_LOG_LEVEL = "DEBUG"
 
 
 def free_port() -> int:
@@ -121,7 +120,6 @@ def run_holo_foreground(
         command.extend(["--model", config.model])
     if config.base_url:
         command.extend(["--base-url", config.base_url])
-    runtime_env = {**os.environ, "HAI_AGENT_RUNTIME_LOG_LEVEL": RUNTIME_DIAGNOSTIC_LOG_LEVEL}
     start = time.monotonic()
     if not stream_output:
         try:
@@ -129,7 +127,6 @@ def run_holo_foreground(
                 command=command,
                 runs_dir=runs_dir,
                 agent_runtime_log_path=agent_runtime_log_path,
-                env=runtime_env,
                 timeout_s=config.timeout_s,
                 start=start,
             )
@@ -145,7 +142,6 @@ def run_holo_foreground(
         stderr=subprocess.PIPE,
         text=True,
         bufsize=1,
-        env=runtime_env,
     )
     stdout_thread = _tee_stream(proc.stdout, sys.stdout, stdout_chunks)
     stderr_thread = _tee_stream(proc.stderr, sys.stderr, stderr_chunks)
@@ -178,7 +174,6 @@ def _run_holo_captured(
     command: list[str],
     runs_dir: Path,
     agent_runtime_log_path: Path,
-    env: dict[str, str],
     timeout_s: float,
     start: float,
 ) -> HoloRunResult:
@@ -188,7 +183,6 @@ def _run_holo_captured(
             cwd=Path(__file__).resolve().parents[2],
             capture_output=True,
             text=True,
-            env=env,
             timeout=timeout_s,
             check=False,
         )

--- a/tests/e2e/_smoke_report.py
+++ b/tests/e2e/_smoke_report.py
@@ -404,6 +404,7 @@ def _write_review_bundle(summaries: list[TaskSmokeSummary], *, root: Path, outpu
             "result.json",
             "stdout.txt",
             "stderr.txt",
+            "runtime.log",
             "platform.json",
         ):
             _copy_review_file(summary.task_dir / name, output_dir / f"{prefix}{name}")

--- a/tests/e2e/_smoke_report.py
+++ b/tests/e2e/_smoke_report.py
@@ -404,10 +404,11 @@ def _write_review_bundle(summaries: list[TaskSmokeSummary], *, root: Path, outpu
             "result.json",
             "stdout.txt",
             "stderr.txt",
-            "runtime.log",
             "platform.json",
         ):
             _copy_review_file(summary.task_dir / name, output_dir / f"{prefix}{name}")
+        for runtime_log in sorted(summary.task_dir.glob("runtime*.log")):
+            _copy_review_file(runtime_log, output_dir / f"{prefix}{runtime_log.name}")
 
 
 def _copy_if_exists(source: Path, destination: Path) -> None:

--- a/tests/e2e/environments/linux.py
+++ b/tests/e2e/environments/linux.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from contextlib import suppress
+from pathlib import Path
+
+from .. import _linux, _preserve
+from .._domain import PreparedTask, TaskCase
+from ..evaluators.finder import CopiedFileEvaluator, FolderExistsEvaluator, ProtectedFileEvaluator
+from ..evaluators.textedit import FileContainsEvaluator
+from ..tasks import (
+    BROWSER_DOWNLOAD_FILE,
+    CALCULATOR_CI_SMOKE,
+    FINDER_COPY_FILE,
+    FINDER_CREATE_FOLDER,
+    FINDER_OPEN_FILE_BY_DOUBLE_CLICK,
+    FINDER_PROTECTED_FILE,
+    FOREGROUND_VISIBLE_EDITOR_WITNESS,
+    TEXTEDIT_TYPE_SENTINEL,
+)
+from ..tasks.browser import prepare_browser_download_task
+
+LINUX_FOREGROUND_TASKS = (
+    FOREGROUND_VISIBLE_EDITOR_WITNESS,
+    TEXTEDIT_TYPE_SENTINEL,
+    FINDER_CREATE_FOLDER,
+    FINDER_COPY_FILE,
+    FINDER_OPEN_FILE_BY_DOUBLE_CLICK,
+    FINDER_PROTECTED_FILE,
+    CALCULATOR_CI_SMOKE,
+    BROWSER_DOWNLOAD_FILE,
+)
+
+
+class LinuxEnvironmentRunner:
+    """Environment runner for the hosted Linux X11 foreground desktop."""
+
+    environment_id = "linux-foreground"
+    task_cases: tuple[TaskCase, ...] = LINUX_FOREGROUND_TASKS
+
+    def supports(self, case: TaskCase) -> bool:
+        return case in self.task_cases
+
+    def preflight(self, case: TaskCase) -> None:
+        if not self.supports(case):
+            raise ValueError(f"{self.environment_id} does not support {case.id}")
+        _linux.require_desktop()
+        command = {
+            "text-editor": "mousepad",
+            "file-manager": "thunar",
+            "calculator": "kcalc",
+            "browser": "google-chrome",
+        }.get(case.app_family)
+        if command is not None:
+            _linux.require_app(command)
+
+    def prepare(self, case: TaskCase, workspace: Path) -> PreparedTask:
+        if case == FOREGROUND_VISIBLE_EDITOR_WITNESS:
+            return self._prepare_foreground_visible_editor_witness(case, workspace)
+        if case == TEXTEDIT_TYPE_SENTINEL:
+            return self._prepare_textedit_type_sentinel(case, workspace)
+        if case == FINDER_CREATE_FOLDER:
+            return self._prepare_finder_create_folder(case, workspace)
+        if case == FINDER_COPY_FILE:
+            return self._prepare_finder_copy_file(case, workspace)
+        if case == FINDER_OPEN_FILE_BY_DOUBLE_CLICK:
+            return self._prepare_finder_open_file_by_double_click(case, workspace)
+        if case == FINDER_PROTECTED_FILE:
+            return self._prepare_finder_protected_file(case, workspace)
+        if case == CALCULATOR_CI_SMOKE:
+            return self._prepare_calculator_ci_smoke(case, workspace)
+        if case == BROWSER_DOWNLOAD_FILE:
+            return self._prepare_browser_download_file(case, workspace)
+        raise ValueError(f"unsupported task case for {self.environment_id}: {case.id}")
+
+    def cleanup(self, prepared: PreparedTask | None) -> None:
+        if prepared is not None:
+            with suppress(Exception):
+                prepared.clean_up()
+
+    def _prepare_foreground_visible_editor_witness(self, case: TaskCase, workspace: Path) -> PreparedTask:
+        _linux.cleanup_editor_and_desktop()
+        sentinel = _linux.unique_token("visibleeditorwitness")
+        target_path = _linux.DESKTOP / f"{_linux.unique_token('witnessfile')}.txt"
+        target_path.write_text("", encoding="utf-8")
+        instruction = (
+            f"Use the visible {_linux.LAUNCHER_TITLE} window to open Mousepad. In Mousepad, open the Desktop file "
+            f"named {target_path.name!r}, type the exact text {sentinel!r}, save with Ctrl+S, then stop. "
+            "Do not use a terminal or any command line tool."
+        )
+        return PreparedTask(
+            case=case,
+            instruction=instruction,
+            workspace=workspace,
+            evaluator=FileContainsEvaluator(target_path, sentinel),
+            metadata={"target_path": str(target_path), "sentinel": sentinel, "app": "Mousepad"},
+            cleanup=_linux.cleanup_editor_and_desktop,
+            preserve_artifacts=lambda artifact_dir: _preserve.copy_path(target_path, artifact_dir),
+        )
+
+    def _prepare_textedit_type_sentinel(self, case: TaskCase, workspace: Path) -> PreparedTask:
+        _linux.cleanup_editor_and_desktop()
+        sentinel = _linux.unique_token("textedittype")
+        target_path = _linux.DESKTOP / f"{_linux.unique_token('typefile')}.txt"
+        target_path.write_text("", encoding="utf-8")
+        _linux.open_in_mousepad(target_path)
+        instruction = (
+            f"The Desktop file {target_path.name!r} is open in Mousepad. Type the exact text {sentinel!r}, "
+            "save with Ctrl+S, then stop. Do not use a terminal or any command line tool."
+        )
+        return PreparedTask(
+            case=case,
+            instruction=instruction,
+            workspace=workspace,
+            evaluator=FileContainsEvaluator(target_path, sentinel),
+            metadata={"target_path": str(target_path), "sentinel": sentinel, "app": "Mousepad"},
+            cleanup=_linux.cleanup_editor_and_desktop,
+            preserve_artifacts=lambda artifact_dir: _preserve.copy_path(target_path, artifact_dir),
+        )
+
+    def _prepare_finder_create_folder(self, case: TaskCase, workspace: Path) -> PreparedTask:
+        _linux.cleanup_file_manager_and_desktop()
+        folder_name = _linux.unique_token("folder")
+        expected_path = _linux.DESKTOP / folder_name
+        _linux.open_desktop_in_thunar()
+
+        def preserve(artifact_dir: Path) -> None:
+            _preserve.write_directory_listing(_linux.DESKTOP, artifact_dir, name="desktop-listing.txt")
+            _preserve.copy_path(expected_path, artifact_dir, name=expected_path.name)
+
+        return PreparedTask(
+            case=case,
+            instruction=(
+                "Thunar is open to the Desktop. Create a new folder with the exact name "
+                f"{folder_name!r}, then stop. Do not use a terminal or any command line tool."
+            ),
+            workspace=workspace,
+            evaluator=FolderExistsEvaluator(expected_path),
+            metadata={"target_path": str(expected_path), "app": "Thunar"},
+            cleanup=_linux.cleanup_file_manager_and_desktop,
+            preserve_artifacts=preserve,
+        )
+
+    def _prepare_finder_copy_file(self, case: TaskCase, workspace: Path) -> PreparedTask:
+        _linux.cleanup_file_manager_and_desktop()
+        source_path = _linux.DESKTOP / f"{_linux.unique_token('copysource')}.txt"
+        folder_path = _linux.DESKTOP / _linux.unique_token("copyfolder")
+        copied_path = folder_path / source_path.name
+        content = f"copy fixture {_linux.unique_token('copycontent')}\n"
+        folder_path.mkdir()
+        source_path.write_text(content, encoding="utf-8")
+        _linux.open_desktop_in_thunar()
+
+        def preserve(artifact_dir: Path) -> None:
+            _preserve.write_directory_listing(_linux.DESKTOP, artifact_dir, name="desktop-listing.txt")
+            _preserve.write_directory_listing(folder_path, artifact_dir, name="target-folder-listing.txt")
+            _preserve.copy_path(source_path, artifact_dir, name=f"source-{source_path.name}")
+            _preserve.copy_path(copied_path, artifact_dir, name=f"copy-{copied_path.name}")
+
+        return PreparedTask(
+            case=case,
+            instruction=(
+                f"Thunar is open to the Desktop. Copy {source_path.name!r} into {folder_path.name!r}; leave the "
+                "original unchanged on the Desktop. Do not use a terminal or any command line tool. Then stop."
+            ),
+            workspace=workspace,
+            evaluator=CopiedFileEvaluator(source_path, copied_path, content),
+            metadata={
+                "source_path": str(source_path),
+                "copied_path": str(copied_path),
+                "folder_path": str(folder_path),
+                "app": "Thunar",
+            },
+            cleanup=_linux.cleanup_file_manager_and_desktop,
+            preserve_artifacts=preserve,
+        )
+
+    def _prepare_finder_open_file_by_double_click(self, case: TaskCase, workspace: Path) -> PreparedTask:
+        _linux.cleanup_opened_file_task()
+        target_path = _linux.DESKTOP / f"{_linux.unique_token('openbydoubleclick')}.txt"
+        content = f"open fixture {_linux.unique_token('opencontent')}\n"
+        target_path.write_text(content, encoding="utf-8")
+        _linux.open_desktop_in_thunar()
+
+        def preserve(artifact_dir: Path) -> None:
+            _preserve.write_directory_listing(_linux.DESKTOP, artifact_dir, name="desktop-listing.txt")
+            _preserve.copy_path(target_path, artifact_dir, name=target_path.name)
+            _linux.preserve_window_titles(artifact_dir)
+
+        return PreparedTask(
+            case=case,
+            instruction=(
+                f"Thunar is open to the Desktop. Open {target_path.name!r} by double-clicking its icon or filename. "
+                "Do not use keyboard shortcuts, menus, a terminal, or any command line tool. Then stop."
+            ),
+            workspace=workspace,
+            evaluator=_linux.LinuxOpenedFileEvaluator(target_path, content),
+            metadata={"target_path": str(target_path), "expected_content": content, "app": "Thunar"},
+            cleanup=_linux.cleanup_opened_file_task,
+            preserve_artifacts=preserve,
+        )
+
+    def _prepare_finder_protected_file(self, case: TaskCase, workspace: Path) -> PreparedTask:
+        _linux.cleanup_file_manager_and_desktop()
+        protected_path = _linux.DESKTOP / f"{_linux.unique_token('protected')}.txt"
+        content = f"protected fixture {_linux.unique_token('protectedcontent')}\n"
+        protected_path.write_text(content, encoding="utf-8")
+        _linux.open_desktop_in_thunar()
+
+        def preserve(artifact_dir: Path) -> None:
+            _preserve.write_directory_listing(_linux.DESKTOP, artifact_dir, name="desktop-listing.txt")
+            _preserve.copy_path(protected_path, artifact_dir, name=protected_path.name)
+
+        return PreparedTask(
+            case=case,
+            instruction=(
+                f"Thunar is open to the Desktop. Confirm {protected_path.name!r} exists, but do not delete, rename, "
+                "move, open, or edit it. Do not use a terminal or any command line tool. Then stop."
+            ),
+            workspace=workspace,
+            evaluator=ProtectedFileEvaluator(protected_path, content),
+            metadata={"protected_path": str(protected_path), "app": "Thunar"},
+            cleanup=_linux.cleanup_file_manager_and_desktop,
+            preserve_artifacts=preserve,
+        )
+
+    def _prepare_calculator_ci_smoke(self, case: TaskCase, workspace: Path) -> PreparedTask:
+        _linux.cleanup_calculator()
+        a, b = 2, 2
+        expected = a + b
+        return PreparedTask(
+            case=case,
+            instruction=(
+                f"Use the visible {_linux.LAUNCHER_TITLE} window to open KCalc. Use only KCalc's visible buttons to "
+                f"compute {a} plus {b}. Clear first if needed, then click {a}, +, {b}, and =. Do not use a terminal, "
+                "Python, or any command line tool. Then stop."
+            ),
+            workspace=workspace,
+            evaluator=_linux.LinuxCalculatorResultEvaluator(a=a, b=b, expected=expected),
+            metadata={"a": a, "b": b, "expected": expected, "app": "KCalc"},
+            cleanup=_linux.cleanup_calculator,
+            preserve_artifacts=_linux.preserve_kcalc_display,
+        )
+
+    def _prepare_browser_download_file(self, case: TaskCase, workspace: Path) -> PreparedTask:
+        _linux.cleanup_chrome()
+        filename = f"{_linux.unique_token('download')}.txt"
+        prepared = prepare_browser_download_task(
+            case=case,
+            workspace=workspace,
+            filename=filename,
+            content=f"download fixture {_linux.unique_token('downloadcontent')}\n",
+            target_path=_linux.DOWNLOADS / filename,
+            browser_name="Google Chrome using the visible Holo E2E Applications launcher",
+            command_line_warning="a terminal, Python,",
+        )
+        metadata = {**prepared.metadata, "app": "Google Chrome"}
+
+        def cleanup() -> None:
+            if prepared.cleanup is not None:
+                prepared.cleanup()
+            _linux.cleanup_chrome()
+
+        return PreparedTask(
+            case=prepared.case,
+            instruction=prepared.instruction,
+            workspace=prepared.workspace,
+            evaluator=prepared.evaluator,
+            metadata=metadata,
+            cleanup=cleanup,
+            preserve_artifacts=prepared.preserve_artifacts,
+        )

--- a/tests/e2e/environments/linux.py
+++ b/tests/e2e/environments/linux.py
@@ -52,6 +52,7 @@ class LinuxEnvironmentRunner:
         }.get(case.app_family)
         if command is not None:
             _linux.require_app(command)
+        _linux.cleanup_test_apps()
 
     def prepare(self, case: TaskCase, workspace: Path) -> PreparedTask:
         if case == FOREGROUND_VISIBLE_EDITOR_WITNESS:

--- a/tests/e2e/environments/linux.py
+++ b/tests/e2e/environments/linux.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from .. import _linux, _preserve
 from .._domain import PreparedTask, TaskCase
+from ..evaluators import linux as _linux_evaluators
 from ..evaluators.finder import CopiedFileEvaluator, FolderExistsEvaluator, ProtectedFileEvaluator
 from ..evaluators.textedit import FileContainsEvaluator
 from ..tasks import (
@@ -185,7 +186,7 @@ class LinuxEnvironmentRunner:
         def preserve(artifact_dir: Path) -> None:
             _preserve.write_directory_listing(_linux.DESKTOP, artifact_dir, name="desktop-listing.txt")
             _preserve.copy_path(target_path, artifact_dir, name=target_path.name)
-            _linux.preserve_window_titles(artifact_dir)
+            _linux_evaluators.preserve_window_titles(artifact_dir)
 
         return PreparedTask(
             case=case,
@@ -194,7 +195,7 @@ class LinuxEnvironmentRunner:
                 "Do not use keyboard shortcuts, menus, a terminal, or any command line tool. Then stop."
             ),
             workspace=workspace,
-            evaluator=_linux.LinuxOpenedFileEvaluator(target_path, content),
+            evaluator=_linux_evaluators.LinuxOpenedFileEvaluator(target_path, content),
             metadata={"target_path": str(target_path), "expected_content": content, "app": "Thunar"},
             cleanup=_linux.cleanup_opened_file_task,
             preserve_artifacts=preserve,
@@ -236,10 +237,10 @@ class LinuxEnvironmentRunner:
                 "Python, or any command line tool. Then stop."
             ),
             workspace=workspace,
-            evaluator=_linux.LinuxCalculatorResultEvaluator(a=a, b=b, expected=expected),
+            evaluator=_linux_evaluators.LinuxCalculatorResultEvaluator(a=a, b=b, expected=expected),
             metadata={"a": a, "b": b, "expected": expected, "app": "KCalc"},
             cleanup=_linux.cleanup_calculator,
-            preserve_artifacts=_linux.preserve_kcalc_display,
+            preserve_artifacts=_linux_evaluators.preserve_kcalc_display,
         )
 
     def _prepare_browser_download_file(self, case: TaskCase, workspace: Path) -> PreparedTask:

--- a/tests/e2e/evaluators/linux.py
+++ b/tests/e2e/evaluators/linux.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from .. import _linux
+from .._domain import EvaluationResult, FailureCategory, FlatMetadata
+from .calculator import calculator_result_part
+
+
+def opened_file_window(filename: str, titles: list[str] | None = None) -> str | None:
+    path = Path(filename)
+    candidates = (path.name, path.stem)
+    visible_titles = titles if titles is not None else [title for _, title in _linux.visible_windows()]
+    for title in visible_titles:
+        folded = title.casefold()
+        if "mousepad" in folded and any(candidate.casefold() in folded for candidate in candidates if candidate):
+            return title
+    return None
+
+
+class LinuxOpenedFileEvaluator:
+    """Proves a seeded file is open in a visible Mousepad window."""
+
+    name = "linux_opened_file"
+
+    def __init__(self, path: Path, expected_content: str) -> None:
+        self.path = path
+        self.expected_content = expected_content
+
+    def evaluate(self) -> EvaluationResult:
+        metadata: FlatMetadata = {"path": str(self.path)}
+        if not self.path.exists():
+            return EvaluationResult(
+                passed=False,
+                message=f"file disappeared before open check: {self.path}",
+                failure_category=FailureCategory.AGENT,
+                metadata=metadata,
+            )
+        if self.path.read_text(encoding="utf-8", errors="replace") != self.expected_content:
+            return EvaluationResult(
+                passed=False,
+                message="seeded file content changed before open check",
+                failure_category=FailureCategory.AGENT,
+                metadata=metadata,
+            )
+        titles = [title for _, title in _linux.visible_windows()]
+        matching_title = opened_file_window(self.path.name, titles)
+        metadata["visible_window_titles"] = titles
+        if matching_title is None:
+            return EvaluationResult(
+                passed=False,
+                message="seeded file was not visible in a Mousepad window",
+                failure_category=FailureCategory.AGENT,
+                metadata=metadata,
+            )
+        return EvaluationResult(
+            passed=True,
+            message="file opened in Mousepad",
+            metadata={**metadata, "mousepad_window_title": matching_title},
+        )
+
+
+class LinuxCalculatorResultEvaluator:
+    """Checks KCalc's visible result through the independent AT-SPI tree."""
+
+    name = "linux_calculator_result"
+
+    def __init__(self, *, a: int, b: int, expected: int) -> None:
+        self.a = a
+        self.b = b
+        self.expected = expected
+
+    def evaluate(self) -> EvaluationResult:
+        entries = kcalc_accessible_entries()
+        display = kcalc_display_from_entries(entries)
+        metadata: FlatMetadata = {
+            "a": self.a,
+            "b": self.b,
+            "expected": self.expected,
+            "accessible_entries": [json.dumps(entry, sort_keys=True) for entry in entries],
+        }
+        if display is None:
+            return EvaluationResult(
+                passed=False,
+                message="KCalc display unreadable via AT-SPI",
+                failure_category=FailureCategory.EVALUATOR,
+                metadata=metadata,
+            )
+        result_part = kcalc_result_part(display)
+        if result_part != str(self.expected):
+            return EvaluationResult(
+                passed=False,
+                message=f"KCalc result mismatch: expected {self.expected!r}, got {result_part!r}",
+                failure_category=FailureCategory.AGENT,
+                metadata={**metadata, "display": display, "result_part": result_part},
+            )
+        return EvaluationResult(
+            passed=True,
+            message="KCalc result matched",
+            metadata={**metadata, "display": display, "result_part": result_part},
+        )
+
+
+def kcalc_accessible_entries() -> list[dict[str, str]]:
+    script = r"""
+import json
+import pyatspi
+
+rows = []
+
+def visit(node, depth=0):
+    if depth > 20:
+        return
+    try:
+        name = node.name or ""
+        role = node.getRoleName() or ""
+    except Exception:
+        return
+    text = ""
+    try:
+        text_iface = node.queryText()
+        text = text_iface.getText(0, text_iface.characterCount)
+    except Exception:
+        pass
+    if name or text:
+        rows.append({"name": name, "role": role, "text": text})
+    try:
+        for child in node:
+            visit(child, depth + 1)
+    except Exception:
+        pass
+
+desktop = pyatspi.Registry.getDesktop(0)
+for app in desktop:
+    try:
+        if "kcalc" in (app.name or "").lower():
+            visit(app)
+    except Exception:
+        pass
+print(json.dumps(rows))
+"""
+    proc = _linux.run_command(["/usr/bin/python3", "-c", script], timeout=10.0)
+    if proc.returncode != 0:
+        return []
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(payload, list):
+        return []
+    return [
+        {key: str(value) for key, value in item.items() if key in {"name", "role", "text"}}
+        for item in payload
+        if isinstance(item, dict)
+    ]
+
+
+def kcalc_display_from_entries(entries: list[dict[str, str]]) -> str | None:
+    display_candidates: list[str] = []
+    text_candidates: list[str] = []
+    numeric_candidates: list[str] = []
+    for entry in entries:
+        role = entry.get("role", "").casefold()
+        values = [entry.get("text", "").strip(), entry.get("name", "").strip()]
+        for value in values:
+            if not value:
+                continue
+            if "display" in entry.get("name", "").casefold() or "display" in role:
+                display_candidates.append(value)
+            if any(kind in role for kind in ("text", "entry", "edit")) and "button" not in role:
+                text_candidates.append(value)
+            if "button" not in role and re.fullmatch(r"[\s\u200e\u200f\d.,+\-*/=]+", value):
+                numeric_candidates.append(value)
+    for candidates in (display_candidates, text_candidates, numeric_candidates):
+        for candidate in reversed(candidates):
+            if re.search(r"\d", candidate):
+                return candidate
+    return None
+
+
+def kcalc_result_part(display: str) -> str:
+    result = calculator_result_part(display)
+    if "=" in result:
+        result = result.rsplit("=", 1)[-1]
+    return result.strip()
+
+
+def preserve_kcalc_display(artifact_dir: Path) -> None:
+    entries = kcalc_accessible_entries()
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    (artifact_dir / "kcalc-atspi.json").write_text(json.dumps(entries, indent=2), encoding="utf-8")
+    display = kcalc_display_from_entries(entries)
+    (artifact_dir / "kcalc-display.txt").write_text(f"{display or ''}\n", encoding="utf-8")
+
+
+def preserve_window_titles(artifact_dir: Path) -> None:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    titles = [title for _, title in _linux.visible_windows()]
+    (artifact_dir / "visible-window-titles.txt").write_text("\n".join(titles) + "\n", encoding="utf-8")

--- a/tests/e2e/test_harness_contract.py
+++ b/tests/e2e/test_harness_contract.py
@@ -587,11 +587,11 @@ def test_calculator_ci_smoke_linux_prepares_two_plus_two(tmp_path: Path) -> None
 def test_linux_kcalc_display_prefers_accessible_display_value() -> None:
     entries = [
         {"name": "7", "role": "push button", "text": ""},
-        {"name": "Display", "role": "text", "text": "4"},
-        {"name": "2 + 2", "role": "label", "text": ""},
+        {"name": "100", "role": "label", "text": ""},
+        {"name": "", "role": "text", "text": "2 + 2 = 4"},
     ]
 
-    assert _linux.kcalc_display_from_entries(entries) == "4"
+    assert _linux.kcalc_display_from_entries(entries) == "2 + 2 = 4"
     assert _linux.kcalc_result_part("2 + 2 = 4") == "4"
 
 

--- a/tests/e2e/test_harness_contract.py
+++ b/tests/e2e/test_harness_contract.py
@@ -246,13 +246,9 @@ def test_run_and_evaluate_rejects_zero_step_holo_run(tmp_path: Path, monkeypatch
 
 def test_holo_run_command_uses_agent_api_runtime_flags(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     captured_command: list[str] = []
-    captured_env: dict[str, str] = {}
 
     def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         captured_command.extend(args)
-        env = kwargs["env"]
-        assert isinstance(env, dict)
-        captured_env.update(env)
         return subprocess.CompletedProcess(args, 0, "", "")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -268,7 +264,6 @@ def test_holo_run_command_uses_agent_api_runtime_flags(tmp_path: Path, monkeypat
     assert "--max-steps" in captured_command
     assert "--max-time-s" in captured_command
     assert "--fast" not in captured_command
-    assert captured_env["HAI_AGENT_RUNTIME_LOG_LEVEL"] == "DEBUG"
 
 
 def test_holo_run_command_passes_fast_when_enabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/e2e/test_harness_contract.py
+++ b/tests/e2e/test_harness_contract.py
@@ -9,7 +9,7 @@ import pytest
 
 from holo_desktop.settings import load_holo_settings
 
-from . import _harness, _linux, _macos, _runner
+from . import _harness, _macos, _runner
 from ._artifacts import E2EArtifacts, E2EResult
 from ._domain import EvaluationResult, FailureCategory, PreparedTask
 from ._environment import UnsupportedEnvironmentError, runner_for_platform
@@ -19,6 +19,7 @@ from .environments import windows as _windows
 from .environments.linux import LINUX_FOREGROUND_TASKS, LinuxEnvironmentRunner
 from .environments.macos import MACOS_FOREGROUND_TASKS
 from .environments.windows import WINDOWS_FOREGROUND_TASKS, WindowsEnvironmentRunner
+from .evaluators import linux as _linux_evaluators
 from .evaluators.browser import DownloadedFileEvaluator
 from .evaluators.calculator import CalculatorResultEvaluator, calculator_result_part
 from .evaluators.finder import CopiedFileEvaluator, OpenedFileEvaluator, ProtectedFileEvaluator
@@ -632,15 +633,15 @@ def test_linux_kcalc_display_prefers_accessible_display_value() -> None:
         {"name": "", "role": "text", "text": "2 + 2 = 4"},
     ]
 
-    assert _linux.kcalc_display_from_entries(entries) == "2 + 2 = 4"
-    assert _linux.kcalc_result_part("2 + 2 = 4") == "4"
+    assert _linux_evaluators.kcalc_display_from_entries(entries) == "2 + 2 = 4"
+    assert _linux_evaluators.kcalc_result_part("2 + 2 = 4") == "4"
 
 
 def test_linux_opened_file_window_requires_mousepad_and_target_name() -> None:
     titles = ["Desktop - Thunar", "other.txt - Mousepad", "fixture.txt - Mousepad"]
 
-    assert _linux.opened_file_window("fixture.txt", titles) == "fixture.txt - Mousepad"
-    assert _linux.opened_file_window("missing.txt", titles) is None
+    assert _linux_evaluators.opened_file_window("fixture.txt", titles) == "fixture.txt - Mousepad"
+    assert _linux_evaluators.opened_file_window("missing.txt", titles) is None
 
 
 def test_finder_open_file_by_double_click_prepares_desktop_text_file(

--- a/tests/e2e/test_harness_contract.py
+++ b/tests/e2e/test_harness_contract.py
@@ -175,6 +175,22 @@ def test_timeout_cleanup_force_kills_after_grace_period() -> None:
     assert message == f"{expected_signal} cleanup exceeded 10s; force-killed"
 
 
+def test_runtime_logs_survive_retried_task_attempts(tmp_path: Path) -> None:
+    artifacts = E2EArtifacts.create(tmp_path / "artifacts")
+    first = tmp_path / "runtime-first.log"
+    second = tmp_path / "runtime-second.log"
+    first.write_text("first attempt timed out\n", encoding="utf-8")
+    second.write_text("second attempt passed\n", encoding="utf-8")
+
+    first_copy = artifacts.copy_runtime_log(first)
+    second_copy = artifacts.copy_runtime_log(second)
+
+    assert first_copy == artifacts.root / "runtime.log"
+    assert second_copy == artifacts.root / "runtime-attempt-2.log"
+    assert first_copy.read_text(encoding="utf-8") == "first attempt timed out\n"
+    assert second_copy.read_text(encoding="utf-8") == "second attempt passed\n"
+
+
 def test_run_and_evaluate_rejects_zero_step_holo_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     event_log_path = tmp_path / "runs" / "events.jsonl"
     event_log_path.parent.mkdir()

--- a/tests/e2e/test_harness_contract.py
+++ b/tests/e2e/test_harness_contract.py
@@ -6,13 +6,14 @@ import pytest
 
 from holo_desktop.settings import load_holo_settings
 
-from . import _harness, _macos
+from . import _harness, _linux, _macos
 from ._artifacts import E2EArtifacts, E2EResult
 from ._domain import EvaluationResult, FailureCategory, PreparedTask
 from ._environment import UnsupportedEnvironmentError, runner_for_platform
 from ._runner import HoloRunResult, find_event_log_path, find_latest_event_log, run_holo_foreground
 from .conftest import HoloLiveConfig, _selected_task_ids
 from .environments import windows as _windows
+from .environments.linux import LINUX_FOREGROUND_TASKS, LinuxEnvironmentRunner
 from .environments.macos import MACOS_FOREGROUND_TASKS
 from .environments.windows import WINDOWS_FOREGROUND_TASKS, WindowsEnvironmentRunner
 from .evaluators.browser import DownloadedFileEvaluator
@@ -436,14 +437,19 @@ def test_windows_runner_supports_stable_ci_task_catalog() -> None:
     assert {task.id for task in WINDOWS_FOREGROUND_TASKS} == STABLE_CI_TASK_IDS
 
 
-def test_double_click_repro_task_is_registered_on_macos_and_windows() -> None:
+def test_linux_runner_supports_stable_ci_task_catalog() -> None:
+    assert {task.id for task in LINUX_FOREGROUND_TASKS} == STABLE_CI_TASK_IDS
+
+
+def test_double_click_repro_task_is_registered_on_all_platforms() -> None:
     assert FINDER_OPEN_FILE_BY_DOUBLE_CLICK.id == "finder_open_file_by_double_click"
     assert FINDER_OPEN_FILE_BY_DOUBLE_CLICK in MACOS_FOREGROUND_TASKS
     assert FINDER_OPEN_FILE_BY_DOUBLE_CLICK in WINDOWS_FOREGROUND_TASKS
+    assert FINDER_OPEN_FILE_BY_DOUBLE_CLICK in LINUX_FOREGROUND_TASKS
 
 
 def test_removed_unstable_task_ids_are_not_registered() -> None:
-    registered_ids = {task.id for task in (*MACOS_FOREGROUND_TASKS, *WINDOWS_FOREGROUND_TASKS)}
+    registered_ids = {task.id for task in (*MACOS_FOREGROUND_TASKS, *WINDOWS_FOREGROUND_TASKS, *LINUX_FOREGROUND_TASKS)}
 
     assert registered_ids.isdisjoint(
         {
@@ -529,17 +535,20 @@ def test_macos_task_preparation_does_not_launch_target_apps(tmp_path: Path, monk
 def test_environment_runner_selection() -> None:
     macos_runner = runner_for_platform("darwin")
     windows_runner = runner_for_platform("win32")
+    linux_runner = runner_for_platform("linux")
 
     assert macos_runner.environment_id == "macos-foreground"
     assert windows_runner.environment_id == "windows-foreground"
+    assert linux_runner.environment_id == "linux-foreground"
     with pytest.raises(UnsupportedEnvironmentError):
-        runner_for_platform("linux")
+        runner_for_platform("freebsd")
 
 
-def test_calculator_ci_smoke_is_available_on_macos_and_windows() -> None:
+def test_calculator_ci_smoke_is_available_on_all_platforms() -> None:
     assert CALCULATOR_CI_SMOKE.id == "calculator_ci_smoke"
     assert CALCULATOR_CI_SMOKE in MACOS_FOREGROUND_TASKS
     assert CALCULATOR_CI_SMOKE in WINDOWS_FOREGROUND_TASKS
+    assert CALCULATOR_CI_SMOKE in LINUX_FOREGROUND_TASKS
 
 
 def test_calculator_ci_smoke_macos_prepares_two_plus_two(tmp_path: Path) -> None:
@@ -564,6 +573,33 @@ def test_calculator_ci_smoke_windows_prepares_two_plus_two(tmp_path: Path) -> No
     assert prepared.metadata["b"] == 2
     assert prepared.metadata["expected"] == 4
     assert prepared.evaluator.name == "windows_calculator_result"
+
+
+def test_calculator_ci_smoke_linux_prepares_two_plus_two(tmp_path: Path) -> None:
+    prepared = LinuxEnvironmentRunner().prepare(CALCULATOR_CI_SMOKE, tmp_path)
+
+    assert "KCalc" in prepared.instruction
+    assert "2 plus 2" in prepared.instruction
+    assert prepared.metadata["expected"] == 4
+    assert prepared.evaluator.name == "linux_calculator_result"
+
+
+def test_linux_kcalc_display_prefers_accessible_display_value() -> None:
+    entries = [
+        {"name": "7", "role": "push button", "text": ""},
+        {"name": "Display", "role": "text", "text": "4"},
+        {"name": "2 + 2", "role": "label", "text": ""},
+    ]
+
+    assert _linux.kcalc_display_from_entries(entries) == "4"
+    assert _linux.kcalc_result_part("2 + 2 = 4") == "4"
+
+
+def test_linux_opened_file_window_requires_mousepad_and_target_name() -> None:
+    titles = ["Desktop - Thunar", "other.txt - Mousepad", "fixture.txt - Mousepad"]
+
+    assert _linux.opened_file_window("fixture.txt", titles) == "fixture.txt - Mousepad"
+    assert _linux.opened_file_window("missing.txt", titles) is None
 
 
 def test_finder_open_file_by_double_click_prepares_desktop_text_file(

--- a/tests/e2e/test_harness_contract.py
+++ b/tests/e2e/test_harness_contract.py
@@ -1,12 +1,15 @@
 import json
+import os
+import signal
 import subprocess
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
 from holo_desktop.settings import load_holo_settings
 
-from . import _harness, _linux, _macos
+from . import _harness, _linux, _macos, _runner
 from ._artifacts import E2EArtifacts, E2EResult
 from ._domain import EvaluationResult, FailureCategory, PreparedTask
 from ._environment import UnsupportedEnvironmentError, runner_for_platform
@@ -115,6 +118,8 @@ def test_holo_max_time_is_inside_subprocess_timeout(tmp_path: Path, monkeypatch:
 
 def test_run_and_evaluate_uses_live_timeout_for_holo_max_time(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     captured_max_time_s: float | None = None
+    runtime_log = tmp_path / "hai-agent-runtime.log"
+    runtime_log.write_text("Attempt #1 failed with APITimeoutError\n", encoding="utf-8")
 
     def fake_run_holo_foreground(**kwargs: object) -> HoloRunResult:
         nonlocal captured_max_time_s
@@ -128,6 +133,7 @@ def test_run_and_evaluate_uses_live_timeout_for_holo_max_time(tmp_path: Path, mo
             stderr="",
             duration_s=1.0,
             event_log_path=None,
+            runtime_log_path=runtime_log,
         )
 
     monkeypatch.setattr(_harness, "run_holo_foreground", fake_run_holo_foreground)
@@ -148,6 +154,25 @@ def test_run_and_evaluate_uses_live_timeout_for_holo_max_time(tmp_path: Path, mo
     )
 
     assert captured_max_time_s == 240.0
+    assert artifacts.runtime_log_path.read_text(encoding="utf-8") == "Attempt #1 failed with APITimeoutError\n"
+    result = json.loads(artifacts.result_path.read_text(encoding="utf-8"))
+    assert result["runtime_log_path"] == str(runtime_log)
+    assert result["copied_runtime_log_path"] == str(artifacts.runtime_log_path)
+
+
+def test_timeout_cleanup_force_kills_after_grace_period() -> None:
+    proc = MagicMock()
+    proc.wait.side_effect = [subprocess.TimeoutExpired(cmd="holo run", timeout=10.0), -9]
+
+    message = _runner._graceful_timeout_cleanup(proc)
+
+    if os.name == "nt":
+        proc.terminate.assert_called_once_with()
+    else:
+        proc.send_signal.assert_called_once_with(signal.SIGINT)
+    proc.kill.assert_called_once_with()
+    expected_signal = "terminate" if os.name == "nt" else "SIGINT"
+    assert message == f"{expected_signal} cleanup exceeded 10s; force-killed"
 
 
 def test_run_and_evaluate_rejects_zero_step_holo_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/e2e/test_harness_contract.py
+++ b/tests/e2e/test_harness_contract.py
@@ -246,9 +246,13 @@ def test_run_and_evaluate_rejects_zero_step_holo_run(tmp_path: Path, monkeypatch
 
 def test_holo_run_command_uses_agent_api_runtime_flags(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     captured_command: list[str] = []
+    captured_env: dict[str, str] = {}
 
     def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         captured_command.extend(args)
+        env = kwargs["env"]
+        assert isinstance(env, dict)
+        captured_env.update(env)
         return subprocess.CompletedProcess(args, 0, "", "")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -264,6 +268,7 @@ def test_holo_run_command_uses_agent_api_runtime_flags(tmp_path: Path, monkeypat
     assert "--max-steps" in captured_command
     assert "--max-time-s" in captured_command
     assert "--fast" not in captured_command
+    assert captured_env["HAI_AGENT_RUNTIME_LOG_LEVEL"] == "DEBUG"
 
 
 def test_holo_run_command_passes_fast_when_enabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/e2e/test_report.py
+++ b/tests/e2e/test_report.py
@@ -233,11 +233,20 @@ def test_write_platform_report_writes_summary_json_markdown_and_jsonl(tmp_path: 
 def test_task_ids_for_platform_returns_registered_runner_tasks() -> None:
     macos_ids = task_ids_for_platform("darwin")
     windows_ids = task_ids_for_platform("win32")
+    linux_ids = task_ids_for_platform("linux")
 
     assert macos_ids == STABLE_CI_TASK_IDS
     assert windows_ids == STABLE_CI_TASK_IDS
+    assert linux_ids == STABLE_CI_TASK_IDS
     assert macos_ids == sorted(macos_ids)
     assert windows_ids == sorted(windows_ids)
+    assert linux_ids == sorted(linux_ids)
+
+
+def test_missing_linux_task_uses_linux_environment_identity(tmp_path: Path) -> None:
+    [result] = ensure_expected_task_results(tmp_path, ["missing"], platform="Linux")
+
+    assert result.environment_id == "linux-foreground"
 
 
 def test_task_ids_for_shard_partition_without_overlap() -> None:

--- a/tests/e2e/test_smoke_report.py
+++ b/tests/e2e/test_smoke_report.py
@@ -180,7 +180,9 @@ def test_github_step_summary_names_visual_artifacts_without_claiming_inline_imag
 def test_render_artifact_root_writes_flat_review_bundle(tmp_path: Path) -> None:
     root = tmp_path / "run-20260616-100000"
     review_bundle = tmp_path / "review-bundle"
-    _write_task_artifacts(root)
+    task_dir = _write_task_artifacts(root)
+    (task_dir / "runtime.log").write_text("first attempt\n", encoding="utf-8")
+    (task_dir / "runtime-attempt-2.log").write_text("second attempt\n", encoding="utf-8")
 
     render_artifact_root(root, review_bundle=review_bundle)
 
@@ -198,6 +200,8 @@ def test_render_artifact_root_writes_flat_review_bundle(tmp_path: Path) -> None:
         "result.json",
         "stdout.txt",
         "stderr.txt",
+        "runtime.log",
+        "runtime-attempt-2.log",
     } <= names
 
 


### PR DESCRIPTION
## Summary

Adds first-class Linux GUI end-to-end coverage for HoloDesktop CLI, stacked on #6.

- provisions a deterministic Ubuntu 22.04 X11 desktop with Xvfb, Openbox, Picom, D-Bus, and AT-SPI
- maps the existing eight stable task contracts to Mousepad, Thunar, KCalc, and Google Chrome
- adds independent KCalc accessibility and opened-file window evaluators
- adds Linux to live smoke and the four-shard full E2E workflow
- bounds full-suite model concurrency to two sessions and adds a platform-scoped manual qualification input (`all` remains the default)
- extends reporting, contract tests, coverage documentation, and local reproduction guidance

## Why

#6 publishes and installs the managed Linux x86_64 runtime, but the existing live suite only proves desktop control on macOS and Windows. This PR closes that confidence gap by exercising the shipped runtime inside a real rendered Linux GUI session and checking externally observable final state.

## Stack

- Base: `feat/linux-runtime-0.1.9`
- Base SHA when branched: `8955498cec62c34912d757909071fa9a1884e05e`
- Head: `8ef65190e1f941cd9ff6aa9dfc7de3b5a34238b5`
- Runtime: `hai-agent-runtime` 0.1.9 Linux x86_64

## Local validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src/`
- `uv run pytest -q` — 428 passed, 14 skipped
- managed Linux runtime CDN artifact/SHA network test
- workflow/action YAML parsing and duplicate-key validation
- composite-action Bash syntax validation
- `git diff --check`

## Hosted validation

Final-head required checks are green:

- [CI: Ubuntu, Windows, macOS](https://github.com/hcompai/holo-desktop-cli/actions/runs/29405482817)
- [Live calculator smoke: Ubuntu, Windows, macOS](https://github.com/hcompai/holo-desktop-cli/actions/runs/29405482824)

The hosted work also found and fixed real Linux workflow defects before this head: missing Xauthority initialization, the missing `gnome-screenshot` backend required by PyAutoGUI, an Openbox readiness race, cross-drive Windows artifact upload, and KCalc's misleading Qt `STATE_SHOWING` value. The corrected KCalc evaluator has hosted evidence reading `2 + 2 = 4` from the AT-SPI text interface and extracting result `4`.

Linux full-suite qualification runs on the final head:

1. [Normal mode](https://github.com/hcompai/holo-desktop-cli/actions/runs/29405798588) — matrix/setup/report/artifact paths worked; three second tasks passed in 8–15 seconds, while unrelated first turns simultaneously produced empty event logs and hit 240-second timeouts.
2. [Fast mode](https://github.com/hcompai/holo-desktop-cli/actions/runs/29406740347) — exposed an upstream runtime packaging defect: runtime 0.1.9 does not contain Hydra config `holo-desktop-holo-3-1-35b-visual-multi-fast`; tasks fail before CUA starts.
3. [Normal mode](https://github.com/hcompai/holo-desktop-cli/actions/runs/29407009992) — reproduced the model-service no-event timeout pattern; KCalc completed and independently evaluated `4` in 26 seconds, while other turns stalled at the model boundary.

Artifacts are preserved on every pass/failure and aggregate reports fail honestly when a task is red. The Linux-only dispatch created exactly four Ubuntu shards, with two admitted concurrently and no macOS/Windows jobs.

## Promotion status

Keep this PR draft. Linux task mappings remain release-candidate coverage until all eight full-suite tasks pass in three independent Ubuntu workflow runs. That 3/3 bar is **not met** today because of the model-service no-event timeouts above. Do not weaken evaluators or add workflow retries to hide that signal. Fast qualification is additionally blocked on the missing runtime config in 0.1.9.
