### PR TITLE
feat: add Grok Build (xAI) to holo install hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ Notable changes per release. Versions follow [SemVer](https://semver.org). Dates
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
-
-- **Grok Build host.** `holo install grok-build` wires the MCP server into [Grok Build](https://github.com/xai-org/grok-build) (xAI) via `grok mcp add` and auto-loads the bundled `holo-desktop` skill from `~/.grok/skills/`.
-
 ## [0.0.1] - Unreleased
 
 Initial public release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes per release. Versions follow [SemVer](https://semver.org). Dates
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+- **Grok Build host.** `holo install grok-build` wires the MCP server into [Grok Build](https://github.com/xai-org/grok-build) (xAI) via `grok mcp add` and auto-loads the bundled `holo-desktop` skill from `~/.grok/skills/`.
+
 ## [0.0.1] - Unreleased
 
 Initial public release.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Each host gets the MCP server in its config, plus a [Skill](https://docs.claude.
 | `codex`         | [Codex](https://github.com/openai/codex)                        | `~/.agents/skills/`          |
 | `copilot`       | [GitHub Copilot CLI](https://github.com/github/copilot-cli)     | —                            |
 | `cursor`        | [Cursor](https://cursor.com)                                    | —                            |
+| `grok-build`    | [Grok Build](https://github.com/xai-org/grok-build) (xAI)       | `~/.grok/skills/`            |
 | `hermes`        | [Hermes](https://nousresearch.com)                              | —                            |
 | `nemoclaw`      | NemoClaw (sandbox bridge)                                       | —                            |
 | `openclaw`      | [OpenClaw](https://github.com/openclaw/openclaw)                | `~/.openclaw/skills/`        |

--- a/src/holo_desktop/cli/hosts.py
+++ b/src/holo_desktop/cli/hosts.py
@@ -236,6 +236,13 @@ CLIENTS: dict[str, Client] = {
         key_path=("mcpServers", BINARY),
         leaf={"type": "stdio", "command": BINARY, "args": ["mcp"]},
     ),
+    "grok-build": Client(
+        name="Grok Build (xAI)",
+        # `grok mcp add` upserts into ~/.grok/config.toml (TOML, so no JSON/YAML merge for us).
+        cli_cmd=("grok", "mcp", "add", BINARY, "--", BINARY, "mcp"),
+        skills_dir=".grok/skills",
+        home_marker=".grok",
+    ),
     "hermes": Client(
         name="Hermes (NousResearch)",
         config_path="~/.hermes/config.yaml",

--- a/tests/test_install_hosts.py
+++ b/tests/test_install_hosts.py
@@ -202,6 +202,30 @@ def test_cli_host_absent_when_binary_missing(sandbox_home: Path, monkeypatch: py
     assert status is hosts.Status.ABSENT
 
 
+def test_grok_build_is_registered_as_cli_host() -> None:
+    client = hosts.CLIENTS["grok-build"]
+
+    assert client.cli_cmd == ("grok", "mcp", "add", "holo", "--", "holo", "mcp")
+    assert client.skills_dir == ".grok/skills"
+    assert client.home_marker == ".grok"
+    assert client.config_path is None
+
+
+def test_grok_build_cli_add_rewrites_binary_after_separator(
+    sandbox_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls = _stub_cli(monkeypatch, result=None)
+    status, _ = hosts.wire_mcp(hosts.CLIENTS["grok-build"])
+    assert status is hosts.Status.INSTALLED
+
+    argv = calls[0]
+    assert argv[0] == "/usr/local/bin/grok"
+    sep = argv.index("--")
+    # The server name before `--` stays bare; `grok mcp add` upserts, so reruns exit 0.
+    assert argv[:sep] == ["/usr/local/bin/grok", "mcp", "add", "holo"]
+    assert argv[sep + 1 :] == [FAKE_HOLO, "mcp"]
+
+
 def test_custom_wire_host_delegates_without_generic_mcp_or_skill(sandbox_home: Path) -> None:
     calls: list[str] = []
     client = hosts.Client(
@@ -253,6 +277,19 @@ def test_skill_idempotent_rerun_skips(sandbox_home: Path) -> None:
     _seed_marker(sandbox_home, client)
     assert hosts.wire_skill(client)[0] is hosts.Status.INSTALLED
     assert hosts.wire_skill(client)[0] is hosts.Status.SKIPPED
+
+
+def test_grok_build_skill_symlink_created_when_host_present(sandbox_home: Path) -> None:
+    client = hosts.CLIENTS["grok-build"]
+    _seed_marker(sandbox_home, client)
+
+    status, _ = hosts.wire_skill(client)
+    assert status is hosts.Status.INSTALLED
+
+    # Grok Build's skill walker follows symlinks (`Path::is_dir()`), so a link is enough.
+    link = sandbox_home / ".grok" / "skills" / hosts.SKILL_NAME
+    assert link.is_symlink()
+    assert (link / "SKILL.md").exists()
 
 
 def test_skill_absent_when_host_not_installed(sandbox_home: Path) -> None:


### PR DESCRIPTION
## Summary

Adds xAI's [Grok Build](https://github.com/xai-org/grok-build) as a supported MCP host under the id `grok-build`.

- `holo install grok-build` wires the server via `grok mcp add holo -- <abs-path>/holo mcp`. Grok Build's config is TOML (`~/.grok/config.toml`), so this uses the CLI-add strategy like `claude-code` and `codex` rather than a JSON/YAML merge.
- Reruns stay idempotent: `grok mcp add` upserts the `[mcp_servers.holo]` entry atomically and exits 0, and also removes the server from `disabled_mcp_servers` if it was disabled.
- The bundled `holo-desktop` skill is symlinked into `~/.grok/skills/`, which Grok auto-loads (its skill walker follows symlinks).
- Host detection via the `~/.grok` marker; one new row in the README host table; CHANGELOG entry.

## How tested

- `make check` (ruff + mypy + pytest) passes on Linux: 417 passed, 23 skipped.
- New tests in `tests/test_install_hosts.py` mirroring the existing CLI-add and skill-wire tests: registration shape, argv rewrite after the `--` separator, and skill symlink creation.
- End to end against a real Grok Build 0.2.101 install: after `holo install grok-build`, `grok mcp list` shows `holo`, `[mcp_servers.holo]` is present in `~/.grok/config.toml` with the rest of the file untouched, and `grok inspect` reports both the MCP server (source: config) and the `holo-desktop` skill (source: user).

## Checklist

- [x] `make check` passes
- [x] Updated `CHANGELOG.md` if this is a user-facing change
- [x] PR title follows the commit convention (e.g. `fix:`, `feat:`, `docs:`)