### PR TITLE
chore: bump version to 0.0.3

### DIFF
--- a/install/manifest.json
+++ b/install/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "holo_version": "0.0.2",
+  "holo_version": "0.0.3",
   "python_version": "3.12",
   "uv_version": "0.9.18",
   "supported_platforms": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "holo-desktop-cli"
-version = "0.0.2"
+version = "0.0.3"
 description = "Vision-language agent that drives real macOS, Linux, and Windows apps. Powered by Holo3; thin client over the hai-agent-runtime agent API."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_install_scripts_static.py
+++ b/tests/test_install_scripts_static.py
@@ -13,7 +13,7 @@ INSTALL_DIR = ROOT / "install"
 def test_manifest_supports_only_v1_platforms_with_real_hashes() -> None:
     manifest = json.loads((INSTALL_DIR / "manifest.json").read_text())
     assert set(manifest["supported_platforms"]) == {"darwin-arm64", "windows-x86_64", "linux-x86_64"}
-    assert manifest["holo_version"] == "0.0.2"
+    assert manifest["holo_version"] == "0.0.3"
     assert manifest["python_version"] == "3.12"
     for entry in manifest["supported_platforms"].values():
         assert re.fullmatch(r"[0-9a-f]{64}", entry["uv_sha256"])

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "holo-desktop-cli"
-version = "0.0.2"
+version = "0.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },


### PR DESCRIPTION
## What

Bump Holo Desktop CLI from `0.0.2` to `0.0.3` so the merged Linux runtime and fresh-install support can be tagged and published.

## Why

`v0.0.2` already exists, and the publish workflow requires the tag version to match `pyproject.toml`.

## Changes

- `pyproject.toml`
- `uv.lock`
- `install/manifest.json`
- installer manifest static test

## Validation

- `uv run ruff check tests/test_install_scripts_static.py tests/test_publish_workflow_static.py`
- `uv run pytest tests/test_install_scripts_static.py tests/test_publish_workflow_static.py -q` (8 passed)
