### PR TITLE
Fix Windows installer architecture detection and release v0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 - Fixed the Windows installer incorrectly rejecting x86_64 systems when PSReadLine shadows .NET's architecture information type.
 
-## [0.0.1] - Unreleased
+## [0.0.3] - 2026-07-21
+
+- Added managed Linux x86_64 runtime installation, installer support, and Linux end-to-end coverage.
+- Added Grok Build (xAI) to the supported `holo install` hosts.
+
+## [0.0.2] - 2026-07-09
+
+- Added consumer install scripts with a managed Python and uv toolchain for macOS Apple Silicon and Windows x86_64.
+- Added the release pipeline that publishes versioned installer assets to GitHub Releases and the public installer CDN.
+
+## [0.0.1] - 2026-06-22
 
 Initial public release.
 
@@ -22,4 +32,6 @@ Initial public release.
 - macOS (Apple Silicon) and Windows ship managed runtime artifacts; macOS Intel and Linux work with a `hai-agent-runtime` on `PATH`.
 
 [0.0.1]: https://github.com/hcompai/holo-desktop-cli/releases/tag/v0.0.1
+[0.0.2]: https://github.com/hcompai/holo-desktop-cli/releases/tag/v0.0.2
+[0.0.3]: https://github.com/hcompai/holo-desktop-cli/releases/tag/v0.0.3
 [0.0.4]: https://github.com/hcompai/holo-desktop-cli/releases/tag/v0.0.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes per release. Versions follow [SemVer](https://semver.org). Dates
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.0.4] - 2026-07-22
+
+- Fixed the Windows installer incorrectly rejecting x86_64 systems when PSReadLine shadows .NET's architecture information type.
+
 ## [0.0.1] - Unreleased
 
 Initial public release.
@@ -18,3 +22,4 @@ Initial public release.
 - macOS (Apple Silicon) and Windows ship managed runtime artifacts; macOS Intel and Linux work with a `hai-agent-runtime` on `PATH`.
 
 [0.0.1]: https://github.com/hcompai/holo-desktop-cli/releases/tag/v0.0.1
+[0.0.4]: https://github.com/hcompai/holo-desktop-cli/releases/tag/v0.0.4

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -10,7 +10,7 @@ function Get-HoloWindowsPlatform {
         [System.Runtime.InteropServices.OSPlatform, mscorlib]::Windows
     )
     if (-not $IsWindows) {
-        Fail "Holo Desktop installer does not support this operating system from install.ps1. Use install.sh on macOS Apple Silicon."
+        Fail "Holo Desktop installer does not support this operating system from install.ps1. Use install.sh on macOS or Linux."
     }
 
     $Architecture = [System.Runtime.InteropServices.RuntimeInformation, mscorlib]::OSArchitecture.ToString()

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -5,18 +5,23 @@ function Fail($Message) {
     exit 1
 }
 
-$IsWindows = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
-    [System.Runtime.InteropServices.OSPlatform]::Windows
-)
-if (-not $IsWindows) {
-    Fail "Holo Desktop installer does not support this operating system from install.ps1. Use install.sh on macOS Apple Silicon."
+function Get-HoloWindowsPlatform {
+    $IsWindows = [System.Runtime.InteropServices.RuntimeInformation, mscorlib]::IsOSPlatform(
+        [System.Runtime.InteropServices.OSPlatform, mscorlib]::Windows
+    )
+    if (-not $IsWindows) {
+        Fail "Holo Desktop installer does not support this operating system from install.ps1. Use install.sh on macOS Apple Silicon."
+    }
+
+    $Architecture = [System.Runtime.InteropServices.RuntimeInformation, mscorlib]::OSArchitecture.ToString()
+    if ($Architecture -ne "X64") {
+        Fail "Holo Desktop installer does not support Windows architecture '$Architecture'. V1 supports windows-x86_64 only."
+    }
+
+    return "windows-x86_64"
 }
 
-if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -ne [System.Runtime.InteropServices.Architecture]::X64) {
-    Fail "Holo Desktop installer does not support Windows ARM64 yet. V1 supports windows-x86_64 only."
-}
-
-$Platform = "windows-x86_64"
+$Platform = Get-HoloWindowsPlatform
 $HoloHome = if ($env:HOLO_HOME) { $env:HOLO_HOME } else { Join-Path $HOME ".holo" }
 $ManifestUrl = if ($env:HOLO_INSTALL_MANIFEST_URL) { $env:HOLO_INSTALL_MANIFEST_URL } else { "https://install.hcompany.ai/install/manifest.json" }
 $TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("holo-install-" + [System.Guid]::NewGuid().ToString("N"))

--- a/install/manifest.json
+++ b/install/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "holo_version": "0.0.3",
+  "holo_version": "0.0.4",
   "python_version": "3.12",
   "uv_version": "0.9.18",
   "supported_platforms": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "holo-desktop-cli"
-version = "0.0.3"
+version = "0.0.4"
 description = "Vision-language agent that drives real macOS, Linux, and Windows apps. Powered by Holo3; thin client over the hai-agent-runtime agent API."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_install_scripts_static.py
+++ b/tests/test_install_scripts_static.py
@@ -4,7 +4,10 @@ import json
 import re
 import shutil
 import subprocess
+import sys
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 INSTALL_DIR = ROOT / "install"
@@ -13,7 +16,7 @@ INSTALL_DIR = ROOT / "install"
 def test_manifest_supports_only_v1_platforms_with_real_hashes() -> None:
     manifest = json.loads((INSTALL_DIR / "manifest.json").read_text())
     assert set(manifest["supported_platforms"]) == {"darwin-arm64", "windows-x86_64", "linux-x86_64"}
-    assert manifest["holo_version"] == "0.0.3"
+    assert manifest["holo_version"] == "0.0.4"
     assert manifest["python_version"] == "3.12"
     for entry in manifest["supported_platforms"].values():
         assert re.fullmatch(r"[0-9a-f]{64}", entry["uv_sha256"])
@@ -41,8 +44,6 @@ def test_install_sh_has_supported_and_unsupported_platform_paths() -> None:
 
 def test_install_ps1_targets_windows_x86_64_and_user_path() -> None:
     text = (INSTALL_DIR / "install.ps1").read_text()
-    assert "IsWindows" in text
-    assert "X64" in text
     assert "[Environment]::SetEnvironmentVariable" in text
     assert "windows-x86_64" in text
     assert "https://install.hcompany.ai/install/manifest.json" in text
@@ -68,6 +69,44 @@ def test_install_ps1_parses_when_powershell_is_available() -> None:
         cwd=ROOT,
         check=True,
     )
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires Windows architecture detection")
+@pytest.mark.parametrize(
+    "shell",
+    [path for name in ("powershell", "pwsh") if (path := shutil.which(name))],
+)
+def test_install_ps1_detects_x64_with_psreadline_loaded(shell: str) -> None:
+    command = r"""
+$tokens = $null
+$errors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    (Resolve-Path 'install/install.ps1'),
+    [ref]$tokens,
+    [ref]$errors
+)
+if ($errors.Count -ne 0) {
+    throw "install.ps1 parse errors: $errors"
+}
+
+foreach ($name in @('Fail', 'Get-HoloWindowsPlatform')) {
+    $definition = $ast.Find({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $name
+    }, $true)
+    if ($null -eq $definition) {
+        throw "install.ps1 does not define $name"
+    }
+    Invoke-Expression $definition.Extent.Text
+}
+
+Import-Module PSReadLine -ErrorAction Stop
+$platform = Get-HoloWindowsPlatform
+if ($platform -ne 'windows-x86_64') {
+    throw "expected windows-x86_64, got '$platform'"
+}
+"""
+    subprocess.run([shell, "-NoProfile", "-Command", command], cwd=ROOT, check=True)
 
 
 def test_holo_help_does_not_expose_installer_bootstrap() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "holo-desktop-cli"
-version = "0.0.3"
+version = "0.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },


### PR DESCRIPTION
## Summary

- resolve `RuntimeInformation` from `mscorlib` so PSReadLine cannot shadow `OSArchitecture`
- report the detected unsupported Windows architecture instead of always claiming ARM64
- add a Windows behavioral regression test that imports PSReadLine and invokes the production detector under Windows PowerShell 5.1 and PowerShell 7 when available
- bump the package and installer manifest to `0.0.4`

## Root cause

In Windows PowerShell with PSReadLine loaded, the unqualified `System.Runtime.InteropServices.RuntimeInformation` lookup can bind to PSReadLine's compatibility type. That type supports `IsOSPlatform` but does not reliably expose `OSArchitecture`, so the installer treated an x86_64 machine as unsupported.

Closes #11.

## Validation

- `uv run pytest tests/test_install_scripts_static.py -q`: 5 passed, 1 Windows-only skip on macOS
- `uv run pytest -q`: 434 passed, 15 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/`
- `uv build`
- package and manifest versions both verified as `0.0.4`
