### PR TITLE
chore: release v0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Notable changes per release. Versions follow [SemVer](https://semver.org). Dates
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.0.5] - 2026-07-28
+
+- Added native Windows ARM64 installation with the managed `hai-agent-runtime` 0.1.10 binary.
+- Added a release-built Windows ARM64 `cryptography` wheel, native installer smoke coverage, and desktop readiness for full end-to-end evaluation.
+
 ## [0.0.4] - 2026-07-22
 
 - Fixed the Windows installer incorrectly rejecting x86_64 systems when PSReadLine shadows .NET's architecture information type.
@@ -35,3 +40,4 @@ Initial public release.
 [0.0.2]: https://github.com/hcompai/holo-desktop-cli/releases/tag/v0.0.2
 [0.0.3]: https://github.com/hcompai/holo-desktop-cli/releases/tag/v0.0.3
 [0.0.4]: https://github.com/hcompai/holo-desktop-cli/releases/tag/v0.0.4
+[0.0.5]: https://github.com/hcompai/holo-desktop-cli/releases/tag/v0.0.5

--- a/install/manifest.json
+++ b/install/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "holo_version": "0.0.4",
+  "holo_version": "0.0.5",
   "python_version": "3.12",
   "uv_version": "0.9.18",
   "supported_platforms": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "holo-desktop-cli"
-version = "0.0.4"
+version = "0.0.5"
 description = "Vision-language agent that drives real macOS, Linux, and Windows apps. Powered by Holo3; thin client over the hai-agent-runtime agent API."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_install_scripts_static.py
+++ b/tests/test_install_scripts_static.py
@@ -22,7 +22,7 @@ def test_manifest_supports_only_v1_platforms_with_real_hashes() -> None:
         "windows-arm64",
         "linux-x86_64",
     }
-    assert manifest["holo_version"] == "0.0.4"
+    assert manifest["holo_version"] == "0.0.5"
     assert manifest["python_version"] == "3.12"
     for entry in manifest["supported_platforms"].values():
         assert re.fullmatch(r"[0-9a-f]{64}", entry["uv_sha256"])

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "holo-desktop-cli"
-version = "0.0.4"
+version = "0.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },


### PR DESCRIPTION
## What

- bump the package, installer manifest, lockfile, and static contract to `0.0.5`
- add the Windows ARM64 release notes

## Why

`v0.0.4` predates native Windows ARM64 support. Tagging the merged release commit as `v0.0.5` will publish the package and GitHub release, build the Windows ARM64 dependency wheel, republish the CDN installer scripts and generated manifest, and run Linux plus Windows ARM64 CDN installer smokes.

## Validation

- `uv lock --check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/`
- `uv run pytest -q` (449 passed, 16 skipped)
- `actionlint .github/workflows/*.yml`
- `git diff --check`
