### PR TITLE
feat: identify CLI via User-Agent on Portal calls

### DIFF
--- a/src/holo_desktop/__init__.py
+++ b/src/holo_desktop/__init__.py
@@ -3,4 +3,5 @@
 from importlib.metadata import version
 
 __version__ = version("holo-desktop-cli")
-__all__ = ["__version__"]
+USER_AGENT = f"holo-desktop-cli/{__version__}"
+__all__ = ["USER_AGENT", "__version__"]

--- a/src/holo_desktop/__init__.py
+++ b/src/holo_desktop/__init__.py
@@ -1,7 +1,17 @@
 """HoloDesktop CLI: thin client to the hai-agent-runtime desktop agent, powered by H Company's Holo3 VLM."""
 
+import platform
 from importlib.metadata import version
 
 __version__ = version("holo-desktop-cli")
 USER_AGENT = f"holo-desktop-cli/{__version__}"
-__all__ = ["USER_AGENT", "__version__"]
+CLIENT_HEADERS = {
+    "User-Agent": USER_AGENT,
+    "X-HCompany-Client-Name": "holo-desktop-cli",
+    "X-HCompany-Client-Version": __version__,
+    "X-HCompany-Client-Type": "cli",
+    "X-HCompany-Language": "Python",
+    "X-HCompany-Runtime": f"python/{platform.python_version()}",
+    "X-HCompany-Platform": f"{platform.system().lower()}/{platform.release()}",
+}
+__all__ = ["CLIENT_HEADERS", "USER_AGENT", "__version__"]

--- a/src/holo_desktop/agent_client/model_gateway.py
+++ b/src/holo_desktop/agent_client/model_gateway.py
@@ -7,7 +7,7 @@ from typing import Literal
 
 import httpx
 
-from holo_desktop import USER_AGENT
+from holo_desktop import CLIENT_HEADERS
 from holo_desktop.settings import GatewaySettings
 
 # This base URL is itself the OpenAI `/v1/models` route, so a GET with the key doubles as an entitlement check.
@@ -27,7 +27,7 @@ def probe_model_access(gateway_url: str, api_key: str, timeout_s: float) -> Gate
     try:
         response = httpx.get(
             gateway_url,
-            headers={"Authorization": f"Bearer {api_key}", "User-Agent": USER_AGENT},
+            headers={**CLIENT_HEADERS, "Authorization": f"Bearer {api_key}"},
             timeout=timeout_s,
         )
     except httpx.HTTPError:

--- a/src/holo_desktop/agent_client/model_gateway.py
+++ b/src/holo_desktop/agent_client/model_gateway.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 import httpx
 
+from holo_desktop import USER_AGENT
 from holo_desktop.settings import GatewaySettings
 
 # This base URL is itself the OpenAI `/v1/models` route, so a GET with the key doubles as an entitlement check.
@@ -24,7 +25,11 @@ def resolve_gateway_url(environ: Mapping[str, str]) -> str:
 def probe_model_access(gateway_url: str, api_key: str, timeout_s: float) -> GatewayAccess:
     """GET the gateway model-list with `api_key`; classify entitled / unauthorized / unverifiable."""
     try:
-        response = httpx.get(gateway_url, headers={"Authorization": f"Bearer {api_key}"}, timeout=timeout_s)
+        response = httpx.get(
+            gateway_url,
+            headers={"Authorization": f"Bearer {api_key}", "User-Agent": USER_AGENT},
+            timeout=timeout_s,
+        )
     except httpx.HTTPError:
         return "unverifiable"
     if response.status_code in (httpx.codes.UNAUTHORIZED, httpx.codes.FORBIDDEN):

--- a/src/holo_desktop/cli/login.py
+++ b/src/holo_desktop/cli/login.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Annotated, Any
 import httpx
 import tyro
 
+from holo_desktop import USER_AGENT
 from holo_desktop.agent_client.model_gateway import (
     GATEWAY_PROBE_TIMEOUT_S,
     probe_model_access,
@@ -225,7 +226,7 @@ def login(
         state = secrets.token_urlsafe(32)
         code, redirect_uri = _await_code(challenge, state, err)
 
-        with httpx.Client(timeout=20.0) as client:
+        with httpx.Client(timeout=20.0, headers={"User-Agent": USER_AGENT}) as client:
             tok = client.post(
                 f"{PORTAL_BASE}/api/auth/desktop/exchange",
                 json={"code": code, "code_verifier": verifier, "redirect_uri": redirect_uri},

--- a/src/holo_desktop/cli/login.py
+++ b/src/holo_desktop/cli/login.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Annotated, Any
 import httpx
 import tyro
 
-from holo_desktop import USER_AGENT
+from holo_desktop import CLIENT_HEADERS
 from holo_desktop.agent_client.model_gateway import (
     GATEWAY_PROBE_TIMEOUT_S,
     probe_model_access,
@@ -226,7 +226,7 @@ def login(
         state = secrets.token_urlsafe(32)
         code, redirect_uri = _await_code(challenge, state, err)
 
-        with httpx.Client(timeout=20.0, headers={"User-Agent": USER_AGENT}) as client:
+        with httpx.Client(timeout=20.0, headers=CLIENT_HEADERS) as client:
             tok = client.post(
                 f"{PORTAL_BASE}/api/auth/desktop/exchange",
                 json={"code": code, "code_verifier": verifier, "redirect_uri": redirect_uri},

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -17,6 +17,7 @@ import httpx
 import pytest
 from rich.console import Console
 
+from holo_desktop import USER_AGENT
 from holo_desktop.cli import bootstrap
 from holo_desktop.cli import profile as profile_mod
 from holo_desktop.cli.profile import Profile
@@ -85,6 +86,7 @@ def _portal_transport() -> httpx.MockTransport:
     """A portal that signs in, lets the prior key be revoked, and mints `fresh-key`."""
 
     def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["user-agent"] == USER_AGENT
         path = request.url.path
         if request.method == "POST" and path.endswith("/api/auth/desktop/exchange"):
             return httpx.Response(200, json={"access_token": "jwt"})

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -17,7 +17,7 @@ import httpx
 import pytest
 from rich.console import Console
 
-from holo_desktop import USER_AGENT
+from holo_desktop import CLIENT_HEADERS
 from holo_desktop.cli import bootstrap
 from holo_desktop.cli import profile as profile_mod
 from holo_desktop.cli.profile import Profile
@@ -86,7 +86,8 @@ def _portal_transport() -> httpx.MockTransport:
     """A portal that signs in, lets the prior key be revoked, and mints `fresh-key`."""
 
     def handler(request: httpx.Request) -> httpx.Response:
-        assert request.headers["user-agent"] == USER_AGENT
+        for key, value in CLIENT_HEADERS.items():
+            assert request.headers[key] == value, key
         path = request.url.path
         if request.method == "POST" and path.endswith("/api/auth/desktop/exchange"):
             return httpx.Response(200, json={"access_token": "jwt"})

--- a/tests/test_model_gateway.py
+++ b/tests/test_model_gateway.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from threading import Thread
 
-from holo_desktop import USER_AGENT
+from holo_desktop import CLIENT_HEADERS
 from holo_desktop.agent_client.model_gateway import (
     PRODUCTION_GATEWAY_URL,
     probe_model_access,
@@ -26,7 +26,8 @@ def _gateway_server(status: int, captured: dict[str, str] | None = None) -> Iter
     class Handler(BaseHTTPRequestHandler):
         def do_GET(self) -> None:
             if captured is not None:
-                captured["user-agent"] = self.headers.get("User-Agent", "")
+                for key in CLIENT_HEADERS:
+                    captured[key.lower()] = self.headers.get(key, "")
             body = b'{"data": []}'
             self.send_response(status)
             self.send_header("Content-Length", str(len(body)))
@@ -55,7 +56,8 @@ def test_probe_identifies_cli_as_user_agent() -> None:
     captured: dict[str, str] = {}
     with _gateway_server(200, captured) as url:
         probe_model_access(url, "good-key", _TIMEOUT_S)
-    assert captured["user-agent"] == USER_AGENT
+    for key, value in CLIENT_HEADERS.items():
+        assert captured[key.lower()] == value, key
 
 
 def test_unauthorized_is_unauthorized() -> None:

--- a/tests/test_model_gateway.py
+++ b/tests/test_model_gateway.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from threading import Thread
 
+from holo_desktop import USER_AGENT
 from holo_desktop.agent_client.model_gateway import (
     PRODUCTION_GATEWAY_URL,
     probe_model_access,
@@ -21,9 +22,11 @@ _TIMEOUT_S = 5.0
 
 
 @contextmanager
-def _gateway_server(status: int) -> Iterator[str]:
+def _gateway_server(status: int, captured: dict[str, str] | None = None) -> Iterator[str]:
     class Handler(BaseHTTPRequestHandler):
         def do_GET(self) -> None:
+            if captured is not None:
+                captured["user-agent"] = self.headers.get("User-Agent", "")
             body = b'{"data": []}'
             self.send_response(status)
             self.send_header("Content-Length", str(len(body)))
@@ -46,6 +49,13 @@ def _gateway_server(status: int) -> Iterator[str]:
 def test_ok_is_entitled() -> None:
     with _gateway_server(200) as url:
         assert probe_model_access(url, "good-key", _TIMEOUT_S) == "entitled"
+
+
+def test_probe_identifies_cli_as_user_agent() -> None:
+    captured: dict[str, str] = {}
+    with _gateway_server(200, captured) as url:
+        probe_model_access(url, "good-key", _TIMEOUT_S)
+    assert captured["user-agent"] == USER_AGENT
 
 
 def test_unauthorized_is_unauthorized() -> None:


### PR DESCRIPTION
## Summary

Portal + model-gateway requests now send the same identification set as the Agents Python SDK:

```
User-Agent:                  holo-desktop-cli/0.0.5
X-HCompany-Client-Name:      holo-desktop-cli
X-HCompany-Client-Version:   0.0.5
X-HCompany-Client-Type:      cli
X-HCompany-Language:         Python
X-HCompany-Runtime:          python/<cpython>
X-HCompany-Platform:         <os>/<release>
```

Matches holotab#802 / the `X-HCompany-*` contract H Data reads. Local runtime and CDN traffic unchanged.

## Test plan

- [x] `uv run pytest tests/test_login.py tests/test_model_gateway.py` (15 passed)
- [x] Portal mock asserts the full header set on every login request
- [x] Gateway loopback captures the same set